### PR TITLE
Fix Docker container networking and Excel export issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,12 +34,18 @@ RUN apt-get update && apt-get install -y \
     zip \
     unzip \
     nginx \
+    python3 \
+    python3-pip \
     && rm -rf /var/lib/apt/lists/*
 # libzip-dev: required to build PHP zip extension
 # libonig-dev: required to build PHP mbstring extension
 # libpng/libjpeg/libfreetype: required for PHP gd extension
 # zip/unzip: required by Composer for extracting packages
 # nginx: web server to convert FastCGI to HTTP
+# python3/python3-pip: required for ClinGen sync pipeline
+
+# Install Python dependencies for ClinGen sync
+RUN pip3 install --break-system-packages openpyxl mysql-connector-python
 
 # Install PHP extensions
 RUN docker-php-ext-configure gd --with-freetype --with-jpeg \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -15,7 +15,12 @@ RUN apt-get update && apt-get install -y \
     git \
     curl \
     default-mysql-client \
+    python3 \
+    python3-pip \
     && rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies for ClinGen sync
+RUN pip3 install --break-system-packages openpyxl mysql-connector-python
 
 # Install PHP extensions
 RUN docker-php-ext-configure gd --with-freetype --with-jpeg \

--- a/app/Http/Controllers/API/SubmissionController.php
+++ b/app/Http/Controllers/API/SubmissionController.php
@@ -1512,6 +1512,7 @@ class SubmissionController extends Controller
     /**
      * Export submissions to Excel using the template file
      * Preserves template formatting and appends data starting at row 13
+     * Accepts SIDs and fetches data from database to avoid POST size limits
      */
     public function exportToTemplate(Request $request)
     {
@@ -1530,34 +1531,80 @@ class SubmissionController extends Controller
 
         Log::info('exportToTemplate: User authenticated: ' . $user->email);
 
-        $submissions = $request->input('submissions');
-        Log::info('exportToTemplate: Received ' . (is_array($submissions) ? count($submissions) : 0) . ' submissions');
+        $sids = $request->input('sids');
+        Log::info('exportToTemplate: Received ' . (is_array($sids) ? count($sids) : 0) . ' SIDs');
 
-        if (empty($submissions) || !is_array($submissions)) {
+        if (empty($sids) || !is_array($sids)) {
             return response()->json([
                 'success' => 'false',
                 'status_code' => 3002,
-                'message' => 'No submissions provided'
+                'message' => 'No submission SIDs provided'
             ], 400);
         }
 
         try {
-            $export = new SubmissionsTemplateExport($submissions);
+            // Fetch submissions from database with relationships
+            // Use the effective submitter query to respect access control
+            $submissions = $this->getEffectiveSubmitterQuery($request, 'submissions')
+                ->whereIn('sid', $sids)
+                ->where('is_most_recent', true)
+                ->with(['gene', 'disease', 'inheritance', 'classification', 'submitter'])
+                ->get();
+
+            Log::info('exportToTemplate: Found ' . $submissions->count() . ' submissions in database');
+
+            // Transform submissions to the format expected by SubmissionsTemplateExport
+            $exportData = $submissions->map(function ($submission) {
+                // Convert submission_data from stdClass to array for array-style access in export
+                $submissionData = json_decode(json_encode($submission->submission_data), true);
+
+                return [
+                    'sid' => $submission->sid,
+                    'local_key' => $submission->local_key,
+                    'submission_data' => $submissionData,
+                    'gene' => [
+                        'hgnc_id' => $submission->gene?->hgnc_id,
+                        'symbol' => $submission->gene?->symbol,
+                    ],
+                    'disease' => [
+                        'curie' => $submission->disease?->curie,
+                        'name' => $submission->disease?->name,
+                    ],
+                    'inheritance' => [
+                        'curie' => $submission->inheritance?->curie,
+                        'name' => $submission->inheritance?->name,
+                    ],
+                    'classification' => [
+                        'curie' => $submission->classification?->curie,
+                        'name' => $submission->classification?->name,
+                    ],
+                    'submitter' => [
+                        'curie' => $submission->submitter?->curie,
+                        'name' => $submission->submitter?->name,
+                    ],
+                    'evidence' => $submission->evidence ?? [],
+                ];
+            })->toArray();
+
+            $export = new SubmissionsTemplateExport($exportData);
             $spreadsheet = $export->generate();
 
-            // Create writer and output
+            // Create writer and save to temp file (more reliable than php://output)
             $writer = new Xlsx($spreadsheet);
-
-            // Create response with proper headers
             $filename = 'submissions_export_' . date('Y-m-d_His') . '.xlsx';
+            $tempFile = storage_path('app/temp/' . $filename);
 
-            return response()->streamDownload(function() use ($writer) {
-                $writer->save('php://output');
-            }, $filename, [
+            // Ensure temp directory exists
+            if (!file_exists(storage_path('app/temp'))) {
+                mkdir(storage_path('app/temp'), 0755, true);
+            }
+
+            $writer->save($tempFile);
+
+            // Return file download response and delete after sending
+            return response()->download($tempFile, $filename, [
                 'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-                'Content-Disposition' => 'attachment; filename="' . $filename . '"',
-                'Cache-Control' => 'max-age=0',
-            ]);
+            ])->deleteFileAfterSend(true);
 
         } catch (\Exception $e) {
             Log::error('Export to template failed: ' . $e->getMessage());

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,7 +8,7 @@
 #
 # Prerequisites:
 #   - Local MySQL running with gencc_sub database prepared
-#   - Run restore-from-production.sh locally first to set up the database
+#   - Run restore-db.sh locally first to set up the database
 
 services:
   app:
@@ -25,24 +25,25 @@ services:
     ports:
       - "8001:8001"   # Laravel dev server
       - "5173:5173"   # Vite HMR
-    extra_hosts:
-      - "host.docker.internal:192.168.127.1"
+    # Note: For Podman on macOS, host.containers.internal auto-resolves to host
     environment:
       - APP_ENV=local
       - APP_DEBUG=true
-      # Use host machine's MySQL (192.168.127.1 is Podman's host gateway on macOS)
+      # Use host machine's MySQL via Podman's built-in host resolution
       - DB_CONNECTION=mysql
-      - DB_HOST=host.docker.internal
+      - DB_HOST=host.containers.internal
       - DB_PORT=3306
       - DB_DATABASE=gencc_sub
       - DB_USERNAME=root
       - DB_PASSWORD=password
+      # Disable SSL for local MySQL connection (avoid self-signed cert issues)
+      - MYSQL_ATTR_SSL_CA=
       - QUEUE_CONNECTION=database
       - CACHE_DRIVER=file
       - SESSION_DRIVER=file
       # Point to gencc-search on host machine
-      - RELEASE_URL=http://host.docker.internal:8000/api/release
-      - SUBMIT_URL=http://host.docker.internal:8001/api/submit
+      - RELEASE_URL=http://host.containers.internal:8000/api/release
+      - SUBMIT_URL=http://host.containers.internal:8001/api/submit
     # Install dependencies on startup, then run dev servers
     command: >
       bash -c "

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "gencc-sub",
+    "name": "html",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/resources/js/Components/SubmissionsListing.vue
+++ b/resources/js/Components/SubmissionsListing.vue
@@ -1090,6 +1090,9 @@
             const xsrfCookie = document.cookie.split('; ').find(row => row.startsWith('XSRF-TOKEN='));
             const xsrfToken = xsrfCookie ? decodeURIComponent(xsrfCookie.split('=')[1]) : '';
 
+            // Send only SIDs to avoid POST size limits - server will fetch full data
+            const sids = filteredData.map(s => s.sid);
+
             const response = await fetch('/api/submissions/export-template', {
                 method: 'POST',
                 credentials: 'same-origin',  // Include cookies for session auth
@@ -1100,7 +1103,7 @@
                     'X-XSRF-TOKEN': xsrfToken
                 },
                 body: JSON.stringify({
-                    submissions: filteredData
+                    sids: sids
                 })
             });
 


### PR DESCRIPTION
## Summary
- Add Python3 and pip dependencies (openpyxl, mysql-connector-python) to Dockerfile and Dockerfile.dev for ClinGen sync pipeline
- Use `host.containers.internal` for Podman host resolution (portable across dev machines, no hardcoded IPs)
- Disable MySQL SSL for local development to avoid self-signed certificate errors
- Fix Excel export POST size limit by sending only SIDs instead of full submission data (~10KB vs 10MB)
- Fix stdClass to array conversion for submission_data in template export

## Test plan
- [ ] Deploy dev container with `./scripts/start-dev-servers.sh`
- [ ] Verify login works (database connection from container)
- [ ] Test GCI Sync Submissions feature
- [ ] Test Download button on submissions listing - Excel file should open without errors
- [ ] Verify exported Excel has correct submission data

🤖 Generated with [Claude Code](https://claude.com/claude-code)