### PR TITLE
Fix GCI Sync download and improve deployment configuration

### DIFF
--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -18,10 +18,13 @@ jobs:
       packages: write
     outputs:
       image: ${{ steps.version.outputs.image }}
-      version: ${{ steps.version.outputs.version }}
+      image_tag: ${{ steps.version.outputs.image_tag }}
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0      # Fetch full history for git describe
+          fetch-tags: true    # Ensure tags are available for version.sh
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -36,18 +39,31 @@ jobs:
       - name: Determine version
         id: version
         run: |
-          # Determine version: manual input > release tag > branch name
+          # Use scripts/version.sh for consistent version generation
+          # Pass manual input as APP_VERSION env var if provided
           if [ -n "${{ inputs.version }}" ]; then
-            VERSION="${{ inputs.version }}"
-          elif [ "${{ github.event_name }}" = "release" ]; then
-            VERSION="${GITHUB_REF_NAME#v}"  # Strip 'v' prefix: v1.2.3 -> 1.2.3
-          else
-            VERSION="${GITHUB_REF_NAME}"  # Use branch name
+            export APP_VERSION="${{ inputs.version }}"
           fi
+          APP_VERSION=$(./scripts/version.sh)
+
+          # Docker image tag for registry
+          if [ -n "${{ inputs.version }}" ]; then
+            IMAGE_TAG="${{ inputs.version }}"
+          elif [ "${{ github.event_name }}" = "release" ]; then
+            IMAGE_TAG="${GITHUB_REF_NAME#v}"  # Strip 'v' prefix: v1.2.3 -> 1.2.3
+          else
+            IMAGE_TAG="${GITHUB_REF_NAME}"  # Use branch name
+          fi
+
           IMAGE="ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')"
 
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "app_version=${APP_VERSION}" >> $GITHUB_OUTPUT
+          echo "image_tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "image=${IMAGE}" >> $GITHUB_OUTPUT
+
+          # Debug: Show what will be passed to Docker build
+          echo "::notice::APP_VERSION=${APP_VERSION}"
+          echo "::notice::IMAGE_TAG=${IMAGE_TAG}"
 
       - name: Build and push Docker image
         id: build
@@ -55,12 +71,14 @@ jobs:
         with:
           context: .
           push: true
+          build-args: |
+            APP_VERSION=${{ steps.version.outputs.app_version }}
           tags: |
-            ${{ steps.version.outputs.image }}:${{ steps.version.outputs.version }}
+            ${{ steps.version.outputs.image }}:${{ steps.version.outputs.image_tag }}
             ${{ steps.version.outputs.image }}:latest
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
-            org.opencontainers.image.version=${{ steps.version.outputs.version }}
+            org.opencontainers.image.version=${{ steps.version.outputs.app_version }}
             org.opencontainers.image.revision=${{ github.sha }}
           cache-from: type=registry,ref=${{ steps.version.outputs.image }}:buildcache
           cache-to: type=registry,ref=${{ steps.version.outputs.image }}:buildcache,mode=max
@@ -87,7 +105,7 @@ jobs:
           STAGING_HOST: ${{ secrets.STAGING_HOST }}
           STAGING_USER: ${{ secrets.STAGING_USER }}
           IMAGE: ${{ needs.build-and-push.outputs.image }}
-          VERSION: ${{ needs.build-and-push.outputs.version }}
+          VERSION: ${{ needs.build-and-push.outputs.image_tag }}
         run: |
           ssh ${STAGING_USER}@${STAGING_HOST} << EOF
             set -e

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,10 @@ RUN composer install --no-dev --no-scripts --ignore-platform-reqs --prefer-dist
 # Build frontend assets
 FROM node:22-alpine AS frontend
 
+# Build argument for app name (can be overridden via --build-arg)
+ARG VITE_APP_NAME="GenCC Submission Portal"
+ENV VITE_APP_NAME=${VITE_APP_NAME}
+
 WORKDIR /app
 
 COPY package.json package-lock.json* ./

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -8,5 +8,16 @@ if [ ! -f /var/www/html/.env ]; then
   exit 1
 fi
 
+# Create storage symlink if it doesn't exist
+# This is required for serving files from storage/app/public via /storage URL
+if [ ! -L /var/www/html/public/storage ]; then
+  echo "Creating storage symlink..."
+  php /var/www/html/artisan storage:link
+fi
+
+# Ensure storage directories exist and are writable
+mkdir -p /var/www/html/storage/app/public
+chown -R www-data:www-data /var/www/html/storage/app/public
+
 # Execute the main command (pm2-runtime)
 exec "$@"

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -4,6 +4,9 @@ server {
     root /var/www/html/public;
     index index.php;
 
+    # Increase client body size for large file uploads
+    client_max_body_size 50M;
+
     location / {
         try_files $uri $uri/ /index.php?$query_string;
     }
@@ -13,6 +16,11 @@ server {
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
         include fastcgi_params;
+
+        # Increase timeouts for long-running requests (e.g., ClinGen sync pipeline)
+        fastcgi_read_timeout 300s;
+        fastcgi_send_timeout 300s;
+        fastcgi_connect_timeout 60s;
     }
 
     location ~ /\.(?!well-known).* {

--- a/docker/php-custom-dev.ini
+++ b/docker/php-custom-dev.ini
@@ -3,3 +3,6 @@
 memory_limit = 2048M
 upload_max_filesize = 20M
 post_max_size = 20M
+
+; Increase max execution time for long-running scripts (e.g., ClinGen sync pipeline)
+max_execution_time = 300

--- a/docker/php-custom.ini
+++ b/docker/php-custom.ini
@@ -2,3 +2,6 @@
 memory_limit = 2048M
 upload_max_filesize = 20M
 post_max_size = 20M
+
+; Increase max execution time for long-running scripts (e.g., ClinGen sync pipeline)
+max_execution_time = 300


### PR DESCRIPTION
## Summary
- Fix GCI Sync file download failing on GCP VM ("File wasn't available on site")
- Fix browser tab showing "Laravel" instead of "GenCC Submission Portal" on deployed container
- Improve APP_VERSION generation to use shared version.sh script
- Increase timeouts for long-running requests

## Changes

### GCI Sync Download Fix
- Add `php artisan storage:link` to `docker/entrypoint.sh` to create symlink for `/storage` URL access
- Ensure `storage/app/public` directory exists and is writable

### Timeout Improvements
- Increase nginx fastcgi timeouts to 300s (`docker/nginx.conf`)
- Add `max_execution_time=300` to both dev and prod PHP configs

### Deployment Workflow Improvements
- Use `scripts/version.sh` for consistent APP_VERSION generation
- Add `fetch-depth: 0` and `fetch-tags: true` for proper git tag detection
- Add `VITE_APP_NAME` build arg to Dockerfile (fixes browser tab title)
- Add debug notices to show build args in workflow logs

## Test plan
- [ ] Deploy to staging using "Deploy to Staging" workflow
- [ ] Verify APP_VERSION shows correctly (not "dev")
- [ ] Verify browser tab shows "GenCC Submission Portal"
- [ ] Test GCI Sync download on staging VM
- [ ] Verify ClinGen sync pipeline completes without timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)