### PR TITLE
Fix CSRF 419 errors on FormData requests

### DIFF
--- a/resources/js/Components/JobItem.vue
+++ b/resources/js/Components/JobItem.vue
@@ -586,7 +586,6 @@ const uploadFile = async (event) => {
 
   try {
     const response = await axios.post(`/api/documents/${props.job.ident}`, formData, {
-      headers: { 'Content-Type': 'multipart/form-data' },
       signal: uploadAbortController.signal
     });
 

--- a/resources/js/Pages/Admin/SubmitterDetail.vue
+++ b/resources/js/Pages/Admin/SubmitterDetail.vue
@@ -45,9 +45,7 @@
             formData.append('allow_submissions', obj.allow_submissions ? '1' : '0')
             formData.append('downloadable', obj.downloadable ? '1' : '0')
 
-            const response = await axios.post('/api/admin/submitters/' + props.submitter.id, formData, {
-                headers: { 'Content-Type': 'multipart/form-data' }
-            })
+            const response = await axios.post('/api/admin/submitters/' + props.submitter.id, formData)
 
             if (response.data.success) {
                 showEdit.value = false

--- a/resources/js/Pages/SubmitterSettings.vue
+++ b/resources/js/Pages/SubmitterSettings.vue
@@ -28,11 +28,7 @@
             if (obj.remove_logo) formData.append('remove_logo', '1');
             if (obj.contact_id !== undefined) formData.append('contact_id', obj.contact_id || '');
 
-            const response = await axios.post('/api/submitters/' + props.submitter.id, formData, {
-                headers: {
-                    'Content-Type': 'multipart/form-data'
-                }
-            });
+            const response = await axios.post('/api/submitters/' + props.submitter.id, formData);
 
             if (response.data.hasOwnProperty('status_code') && response.data.status_code == 200) {
                 showEdit.value = false;


### PR DESCRIPTION
## Summary
- Remove explicit `Content-Type: multipart/form-data` headers from axios FormData requests
- Fixes HTTP 419 CSRF token mismatch errors on submitter edit and file upload operations

## Problem
When manually setting `Content-Type: multipart/form-data` in axios request headers, it overrides the default headers configured in `bootstrap.js`, which include the CSRF token (`X-CSRF-TOKEN`). This caused all FormData POST requests to fail with a 419 error.

## Solution
Let axios handle the Content-Type header automatically. When axios detects a FormData object, it:
1. Sets the correct `Content-Type: multipart/form-data` with the required boundary parameter
2. Preserves the default CSRF token headers

## Files Changed
- `resources/js/Components/JobItem.vue` - Document upload
- `resources/js/Pages/Admin/SubmitterDetail.vue` - Admin submitter edit
- `resources/js/Pages/SubmitterSettings.vue` - Submitter settings edit

## Test plan
- [ ] Edit a submitter from the admin panel - should save successfully
- [ ] Edit submitter settings from the submitter settings page - should save successfully  
- [ ] Upload a file to a job - should upload and process successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)