### PR TITLE
Fix session corruption from double middleware on API routes

### DIFF
--- a/resources/js/Components/JobItem.vue
+++ b/resources/js/Components/JobItem.vue
@@ -467,8 +467,13 @@ const pollUploadProgress = async () => {
 
   } catch (error) {
     console.error('[Upload] Polling error:', error);
-    // Retry after 5 seconds on network error
-    setTimeout(pollUploadProgress, 5000);
+    const status = error.response?.status;
+    if (status === 401 || status === 403 || status === 419) {
+      // Session expired or unauthorized — stop polling, don't flood the server
+      stopPolling();
+      return;
+    }
+    // For transient/network errors: let the existing setInterval handle retries
   }
 };
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -75,7 +75,7 @@ Route::get('/status/job/{id}', [SubmitController::class, 'status']);
  * Various calls for validating and updating the submission relations
  * 
  */
-Route::group(['middleware' => ['web']], function () {
+Route::group(['middleware' => ['auth:sanctum']], function () {
 
     // endpoint for checking on a disease
     Route::get('/lookup/disease/{id}', [DiseaseController::class, 'show']);
@@ -179,7 +179,7 @@ Route::post('/sim', [SubmitController::class, 'pubrec']);
  * These require GenCC Administrator privileges
  * Uses web middleware for session auth; CSRF excluded in VerifyCsrfToken
  */
-Route::group(['middleware' => ['web'], 'prefix' => 'admin'], function () {
+Route::group(['middleware' => ['auth:sanctum'], 'prefix' => 'admin'], function () {
     // Operational commands
     Route::post('/run-publish', [AdminController::class, 'runPublish']);
     Route::post('/repair-release', [AdminController::class, 'repairRelease']);

--- a/tests/Feature/AdminControllerTest.php
+++ b/tests/Feature/AdminControllerTest.php
@@ -103,16 +103,16 @@ class AdminControllerTest extends TestCase
     public function test_unauthenticated_cannot_access_admin_endpoints(): void
     {
         $response = $this->postJson('/api/admin/run-publish');
-        $response->assertStatus(403);
+        $response->assertStatus(401);
 
         $response = $this->postJson('/api/admin/update-diseases');
-        $response->assertStatus(403);
+        $response->assertStatus(401);
 
         $response = $this->postJson('/api/admin/update-genes');
-        $response->assertStatus(403);
+        $response->assertStatus(401);
 
         $response = $this->postJson('/api/admin/sync-pubmed');
-        $response->assertStatus(403);
+        $response->assertStatus(401);
     }
 
     /**

--- a/tests/Feature/SubmissionApiTest.php
+++ b/tests/Feature/SubmissionApiTest.php
@@ -484,12 +484,7 @@ class SubmissionApiTest extends TestCase
             'job' => $this->job->ident
         ]);
 
-        $response->assertStatus(200);
-        $response->assertJson([
-            'success' => 'false',
-            'status_code' => 3001,
-            'message' => 'Unauthorized'
-        ]);
+        $response->assertStatus(401);
     }
 
     /**
@@ -643,7 +638,6 @@ class SubmissionApiTest extends TestCase
 
     /**
      * Test update requires authentication
-     * Routes under web middleware return 403 when not authenticated
      */
     public function test_update_requires_authentication(): void
     {
@@ -652,8 +646,7 @@ class SubmissionApiTest extends TestCase
             'public' => 'test'
         ]);
 
-        // Without authentication, web middleware returns 403
-        $response->assertStatus(403);
+        $response->assertStatus(401);
     }
 
     /**
@@ -1058,11 +1051,7 @@ class SubmissionApiTest extends TestCase
             'sids' => [$this->submission->sid]
         ]);
 
-        $response->assertStatus(200);
-        $response->assertJson([
-            'success' => 'false',
-            'status_code' => 3001
-        ]);
+        $response->assertStatus(401);
     }
 
     /**


### PR DESCRIPTION
The `web` middleware group on API route groups in `routes/api.php` duplicated EncryptCookies/StartSession already provided by Sanctum's EnsureFrontendRequestsAreStateful, causing double cookie encryption that destroyed the session on every request. This made the upload progress polling return 403, froze the progress bar, and corrupted the session cookie so any subsequent navigation logged the user out.

Replace `web` with `auth:sanctum` on both the main and admin API route groups. Also stop upload progress polling on auth errors (401/403/419) instead of retrying indefinitely, which was flooding the server with failing requests.