### PR TITLE
Fix TSV exports to not quote values

### DIFF
--- a/app/Console/Commands/GenccRelease.php
+++ b/app/Console/Commands/GenccRelease.php
@@ -1483,11 +1483,12 @@ class GenccRelease extends Command
             $this->warn("  Failed to generate XLS: {$e->getMessage()}");
         }
 
-        // Generate TSV
+        // Generate TSV (Excel::TSV doesn't set tab delimiter automatically, so we pass it explicitly)
         try {
+            $tsvExport = new ReleaseSubmissionExport(delimiter: "\t");
             $tsvDir = $currentDir . '/tsv';
             $tsvTimestamped = $tsvDir . '/' . $timestampedBase . '.tsv';
-            Excel::store($export, 'public/current/tsv/' . $timestampedBase . '.tsv', 'local', \Maatwebsite\Excel\Excel::TSV);
+            Excel::store($tsvExport, 'public/current/tsv/' . $timestampedBase . '.tsv', 'local', \Maatwebsite\Excel\Excel::TSV);
             $tsvContent = File::get($tsvTimestamped);
             $this->uploadToGcs($tsvContent, "current/tsv/{$timestampedBase}.tsv",
                 'text/tab-separated-values', $tsvTimestamped);
@@ -1587,11 +1588,12 @@ class GenccRelease extends Command
             $this->warn("    Failed to generate legacy XLS: {$e->getMessage()}");
         }
 
-        // Generate legacy TSV
+        // Generate legacy TSV (Excel::TSV doesn't set tab delimiter automatically, so we pass it explicitly)
         try {
+            $legacyTsvExport = new ReleaseSubmissionExport(useLegacyFormat: true, delimiter: "\t");
             $tsvDir = $legacyDir . '/tsv';
             $tsvTimestamped = $tsvDir . '/' . $timestampedBase . '.tsv';
-            Excel::store($legacyExport, 'public/legacy/tsv/' . $timestampedBase . '.tsv', 'local', \Maatwebsite\Excel\Excel::TSV);
+            Excel::store($legacyTsvExport, 'public/legacy/tsv/' . $timestampedBase . '.tsv', 'local', \Maatwebsite\Excel\Excel::TSV);
             $tsvContent = File::get($tsvTimestamped);
             $this->uploadToGcs($tsvContent, "legacy/tsv/{$timestampedBase}.tsv",
                 'text/tab-separated-values', $tsvTimestamped);

--- a/app/Console/Commands/GenccRelease.php
+++ b/app/Console/Commands/GenccRelease.php
@@ -1484,8 +1484,9 @@ class GenccRelease extends Command
         }
 
         // Generate TSV (Excel::TSV doesn't set tab delimiter automatically, so we pass it explicitly)
+        // Also disable enclosure (quoting) for proper TSV format
         try {
-            $tsvExport = new ReleaseSubmissionExport(delimiter: "\t");
+            $tsvExport = new ReleaseSubmissionExport(delimiter: "\t", enclosure: '');
             $tsvDir = $currentDir . '/tsv';
             $tsvTimestamped = $tsvDir . '/' . $timestampedBase . '.tsv';
             Excel::store($tsvExport, 'public/current/tsv/' . $timestampedBase . '.tsv', 'local', \Maatwebsite\Excel\Excel::TSV);
@@ -1589,8 +1590,9 @@ class GenccRelease extends Command
         }
 
         // Generate legacy TSV (Excel::TSV doesn't set tab delimiter automatically, so we pass it explicitly)
+        // Also disable enclosure (quoting) for proper TSV format
         try {
-            $legacyTsvExport = new ReleaseSubmissionExport(useLegacyFormat: true, delimiter: "\t");
+            $legacyTsvExport = new ReleaseSubmissionExport(useLegacyFormat: true, delimiter: "\t", enclosure: '');
             $tsvDir = $legacyDir . '/tsv';
             $tsvTimestamped = $tsvDir . '/' . $timestampedBase . '.tsv';
             Excel::store($legacyTsvExport, 'public/legacy/tsv/' . $timestampedBase . '.tsv', 'local', \Maatwebsite\Excel\Excel::TSV);

--- a/app/Exports/ReleaseSubmissionExport.php
+++ b/app/Exports/ReleaseSubmissionExport.php
@@ -7,15 +7,18 @@ use Maatwebsite\Excel\Concerns\FromQuery;
 use Maatwebsite\Excel\Concerns\WithMapping;
 use Maatwebsite\Excel\Concerns\Exportable;
 use Maatwebsite\Excel\Concerns\WithHeadings;
-use Maatwebsite\Excel\Concerns\WithCustomCsvSettings;
 
 /**
  * CSV/XLSX Export for release submissions - uses FromQuery for efficient chunked processing.
  * This significantly reduces memory usage by not loading all 25K+ records at once.
  *
  * Matches the gencc-search SubmissionExport format exactly.
+ *
+ * Note: Do NOT implement WithCustomCsvSettings here - it would override the delimiter
+ * for both CSV and TSV exports. The default comma delimiter for CSV is correct,
+ * and TSV uses its own tab delimiter when Excel::TSV is specified.
  */
-class ReleaseSubmissionExport implements FromQuery, WithHeadings, WithMapping, WithCustomCsvSettings
+class ReleaseSubmissionExport implements FromQuery, WithHeadings, WithMapping
 {
     use Exportable;
 
@@ -183,16 +186,6 @@ class ReleaseSubmissionExport implements FromQuery, WithHeadings, WithMapping, W
         }
 
         return array_merge(['sgc_id', 'version_number'], $commonHeadings);
-    }
-
-    /**
-     * CSV settings.
-     */
-    public function getCsvSettings(): array
-    {
-        return [
-            'delimiter' => ',',
-        ];
     }
 
     /**

--- a/app/Exports/ReleaseSubmissionExport.php
+++ b/app/Exports/ReleaseSubmissionExport.php
@@ -26,10 +26,13 @@ class ReleaseSubmissionExport implements FromQuery, WithHeadings, WithMapping, W
 
     private string $delimiter;
 
-    public function __construct(bool $useLegacyFormat = false, string $delimiter = ',')
+    private string $enclosure;
+
+    public function __construct(bool $useLegacyFormat = false, string $delimiter = ',', string $enclosure = '"')
     {
         $this->useLegacyFormat = $useLegacyFormat;
         $this->delimiter = $delimiter;
+        $this->enclosure = $enclosure;
     }
 
     /**
@@ -192,12 +195,14 @@ class ReleaseSubmissionExport implements FromQuery, WithHeadings, WithMapping, W
     }
 
     /**
-     * CSV settings — controls the delimiter for CSV/TSV exports.
+     * CSV settings — controls the delimiter and enclosure for CSV/TSV exports.
+     * For TSV, enclosure should be empty string to avoid quoting values.
      */
     public function getCsvSettings(): array
     {
         return [
             'delimiter' => $this->delimiter,
+            'enclosure' => $this->enclosure,
         ];
     }
 

--- a/app/Exports/ReleaseSubmissionExport.php
+++ b/app/Exports/ReleaseSubmissionExport.php
@@ -7,6 +7,7 @@ use Maatwebsite\Excel\Concerns\FromQuery;
 use Maatwebsite\Excel\Concerns\WithMapping;
 use Maatwebsite\Excel\Concerns\Exportable;
 use Maatwebsite\Excel\Concerns\WithHeadings;
+use Maatwebsite\Excel\Concerns\WithCustomCsvSettings;
 
 /**
  * CSV/XLSX Export for release submissions - uses FromQuery for efficient chunked processing.
@@ -14,19 +15,21 @@ use Maatwebsite\Excel\Concerns\WithHeadings;
  *
  * Matches the gencc-search SubmissionExport format exactly.
  *
- * Note: Do NOT implement WithCustomCsvSettings here - it would override the delimiter
- * for both CSV and TSV exports. The default comma delimiter for CSV is correct,
- * and TSV uses its own tab delimiter when Excel::TSV is specified.
+ * Note: Excel::TSV is just an alias for 'Csv' in Maatwebsite Excel — it does NOT
+ * automatically use tab delimiters. Pass delimiter: "\t" to the constructor for TSV.
  */
-class ReleaseSubmissionExport implements FromQuery, WithHeadings, WithMapping
+class ReleaseSubmissionExport implements FromQuery, WithHeadings, WithMapping, WithCustomCsvSettings
 {
     use Exportable;
 
     private bool $useLegacyFormat;
 
-    public function __construct(bool $useLegacyFormat = false)
+    private string $delimiter;
+
+    public function __construct(bool $useLegacyFormat = false, string $delimiter = ',')
     {
         $this->useLegacyFormat = $useLegacyFormat;
+        $this->delimiter = $delimiter;
     }
 
     /**
@@ -186,6 +189,16 @@ class ReleaseSubmissionExport implements FromQuery, WithHeadings, WithMapping
         }
 
         return array_merge(['sgc_id', 'version_number'], $commonHeadings);
+    }
+
+    /**
+     * CSV settings — controls the delimiter for CSV/TSV exports.
+     */
+    public function getCsvSettings(): array
+    {
+        return [
+            'delimiter' => $this->delimiter,
+        ];
     }
 
     /**


### PR DESCRIPTION
## Summary
TSV files were being generated with all values enclosed in double quotes. Standard TSV format should not quote values unless they contain special characters.

## Problem
```
"SGC-100001"	"1"	"HGNC:10896"	"SDHD"
```

## Solution
Added configurable `enclosure` parameter to `ReleaseSubmissionExport`:
- Defaults to `"` for CSV (standard quoting)
- Set to empty string `''` for TSV exports (no quoting)

## Expected output after fix
```
SGC-100001	1	HGNC:10896	SDHD
```

## Test plan
- [ ] Run `php artisan gencc:release process` and verify TSV files have no quotes
- [ ] Verify CSV files still have proper quoting when values contain special characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)