### PR TITLE
Add nginx security hardening and fail2ban

### DIFF
--- a/deployment/ansible/README.md
+++ b/deployment/ansible/README.md
@@ -73,7 +73,7 @@ The `nginx_tls` role deploys several layers of abuse prevention, configured via 
 
 **IP blocklist** — `gencc-ip-blocklist.conf.j2` renders `deny` directives from the `gencc_blocked_ips` Ansible variable. Re-run the playbook to update.
 
-**Security headers** — HSTS, X-Content-Type-Options, X-Frame-Options, and Referrer-Policy are set on all responses (including errors). HSTS max-age is configurable per environment (`gencc_hsts_max_age`).
+**Security headers** — HSTS, X-Content-Type-Options, X-Frame-Options, and Referrer-Policy are set on the main HTTPS application responses (including error responses from that vhost). Redirect-only vhosts may still return bare `301` responses without these headers. HSTS max-age is configurable per environment (`gencc_hsts_max_age`).
 
 **fail2ban** — Monitors nginx logs over longer windows and bans repeat offenders at the iptables level. Four jails are configured:
 

--- a/deployment/ansible/README.md
+++ b/deployment/ansible/README.md
@@ -61,6 +61,38 @@ The restore is destructive: it drops and recreates `gencc_mysql_database`.
 
 (See `./deployment/ansible/inventories/group_vars/all/vars.yml` for all config options)
 
+## Security hardening
+
+The `nginx_tls` role deploys several layers of abuse prevention, configured via templates in `roles/nginx_tls/templates/`:
+
+**Bot blocking** — A user-agent map (`gencc-security.conf.j2`) blocks known SEO crawlers, AI training bots, and vulnerability scanners. Certain paths (downloads, health checks, robots.txt) are exempt so external tools can still fetch exports.
+
+**Rate limiting** — nginx `limit_req` zones throttle requests per client IP. Different zones apply to different route types (general pages, auth endpoints, search, data exports). Limits are defined at the `http` level in `gencc-security.conf.j2` and applied per-location in `gencc-https.conf.j2`.
+
+**Connection limiting** — `limit_conn` caps simultaneous connections per IP (30 general, 3 for exports), protecting against slowloris-style attacks and download abuse.
+
+**IP blocklist** — `gencc-ip-blocklist.conf.j2` renders `deny` directives from the `gencc_blocked_ips` Ansible variable. Re-run the playbook to update.
+
+**Security headers** — HSTS, X-Content-Type-Options, X-Frame-Options, and Referrer-Policy are set on all responses (including errors). HSTS max-age is configurable per environment (`gencc_hsts_max_age`).
+
+**fail2ban** — Monitors nginx logs over longer windows and bans repeat offenders at the iptables level. Four jails are configured:
+
+| Jail | Watches | Triggers on | Ban duration |
+|------|---------|-------------|-------------|
+| `sshd` | auth.log | SSH brute force | 1 hour |
+| `nginx-req-limit` | error.log | Repeated rate-limit 429s | 10 minutes |
+| `nginx-forbidden` | access.log | Repeated bot-blocked 403s | 24 hours |
+| `nginx-botsearch` | access.log | Vulnerability probe paths (wp-admin, .env, .git, etc.) | 24 hours |
+
+GCP IAP tunnel IPs (`35.235.240.0/20`) are in `ignoreip` so fail2ban never locks out SSH operators.
+
+Useful operational commands:
+```bash
+fail2ban-client status                              # List all jails
+fail2ban-client status nginx-req-limit              # Show banned IPs for a jail
+fail2ban-client set nginx-req-limit unbanip 1.2.3.4 # Manual unban
+```
+
 ## Notes
 - Uses **rootless Podman** for the app containers via a dedicated `gencc` user and `loginctl enable-linger`.
 - Uses **host MySQL** and allows container connections via `slirp4netns` (`DB_HOST=10.0.2.2`).

--- a/deployment/ansible/inventories/group_vars/all/vars.yml
+++ b/deployment/ansible/inventories/group_vars/all/vars.yml
@@ -37,6 +37,17 @@ gencc_submit_hostname_redirects: []
 gencc_search_hostname_redirects: []
 
 # -----------------------------------------------------------------------------
+# Security hardening
+# -----------------------------------------------------------------------------
+# HSTS max-age in seconds (1 year). Override to 300 on staging.
+gencc_hsts_max_age: 31536000
+
+# IPs to block at nginx level (individual IPs and CIDR ranges)
+gencc_blocked_ips: []
+  # - 185.100.157.14
+  # - 47.246.164.0/24
+
+# -----------------------------------------------------------------------------
 # Database bootstrap
 # -----------------------------------------------------------------------------
 # Choose one:

--- a/deployment/ansible/inventories/group_vars/staging/vars.yml
+++ b/deployment/ansible/inventories/group_vars/staging/vars.yml
@@ -15,3 +15,6 @@ gencc_letsencrypt_domains:
 
 # Systemd timers for scheduled tasks
 gencc_enable_timers: true
+
+# Security: short HSTS max-age on staging (5 minutes)
+gencc_hsts_max_age: 300

--- a/deployment/ansible/roles/nginx_tls/handlers/main.yml
+++ b/deployment/ansible/roles/nginx_tls/handlers/main.yml
@@ -3,3 +3,8 @@
   ansible.builtin.service:
     name: nginx
     state: reloaded
+
+- name: restart fail2ban
+  ansible.builtin.service:
+    name: fail2ban
+    state: restarted

--- a/deployment/ansible/roles/nginx_tls/tasks/main.yml
+++ b/deployment/ansible/roles/nginx_tls/tasks/main.yml
@@ -1,9 +1,10 @@
 ---
-- name: Install nginx + certbot dependencies
+- name: Install nginx + certbot + fail2ban dependencies
   ansible.builtin.apt:
     name:
       - nginx
       - certbot
+      - fail2ban
       - ca-certificates
       - curl
     state: present
@@ -24,6 +25,33 @@
     owner: root
     group: root
     mode: "0755"
+
+- name: Deploy nginx security config (http-level rate limits, bot maps)
+  ansible.builtin.template:
+    src: gencc-security.conf.j2
+    dest: /etc/nginx/conf.d/gencc-security.conf
+    owner: root
+    group: root
+    mode: "0644"
+  notify: reload nginx
+
+- name: Deploy nginx IP blocklist
+  ansible.builtin.template:
+    src: gencc-ip-blocklist.conf.j2
+    dest: /etc/nginx/snippets/gencc-ip-blocklist.conf
+    owner: root
+    group: root
+    mode: "0644"
+  notify: reload nginx
+
+- name: Deploy nginx proxy params snippet
+  ansible.builtin.template:
+    src: gencc-proxy-params.conf.j2
+    dest: /etc/nginx/snippets/gencc-proxy-params.conf
+    owner: root
+    group: root
+    mode: "0644"
+  notify: reload nginx
 
 - name: Disable default nginx site
   ansible.builtin.file:
@@ -97,3 +125,49 @@
     state: started
     enabled: true
   when: gencc_enable_letsencrypt | bool
+
+# ---------------------------------------------------------------------------
+# fail2ban
+# ---------------------------------------------------------------------------
+
+- name: Deploy fail2ban jail config
+  ansible.builtin.template:
+    src: fail2ban/jail.local.j2
+    dest: /etc/fail2ban/jail.local
+    owner: root
+    group: root
+    mode: "0644"
+  notify: restart fail2ban
+
+- name: Deploy fail2ban nginx rate-limit filter
+  ansible.builtin.template:
+    src: fail2ban/filter-nginx-ratelimit.conf.j2
+    dest: /etc/fail2ban/filter.d/nginx-ratelimit.conf
+    owner: root
+    group: root
+    mode: "0644"
+  notify: restart fail2ban
+
+- name: Deploy fail2ban nginx forbidden filter
+  ansible.builtin.template:
+    src: fail2ban/filter-nginx-forbidden.conf.j2
+    dest: /etc/fail2ban/filter.d/nginx-forbidden.conf
+    owner: root
+    group: root
+    mode: "0644"
+  notify: restart fail2ban
+
+- name: Deploy fail2ban nginx botsearch filter
+  ansible.builtin.template:
+    src: fail2ban/filter-nginx-botsearch.conf.j2
+    dest: /etc/fail2ban/filter.d/nginx-botsearch.conf
+    owner: root
+    group: root
+    mode: "0644"
+  notify: restart fail2ban
+
+- name: Enable and start fail2ban
+  ansible.builtin.service:
+    name: fail2ban
+    state: started
+    enabled: true

--- a/deployment/ansible/roles/nginx_tls/tasks/main.yml
+++ b/deployment/ansible/roles/nginx_tls/tasks/main.yml
@@ -119,6 +119,31 @@
     - gencc_le_cert.stat.exists
   notify: reload nginx
 
+- name: Validate nginx config syntax
+  ansible.builtin.command: nginx -t
+  changed_when: false
+
+- name: Render nginx config for hardening validation
+  ansible.builtin.command: nginx -T
+  register: gencc_nginx_rendered_config
+  changed_when: false
+  when:
+    - gencc_enable_letsencrypt | bool
+    - gencc_le_cert.stat.exists
+
+- name: Assert hardened HTTPS nginx config is rendered
+  ansible.builtin.assert:
+    that:
+      - "'access_log /var/log/nginx/access.log gencc' in gencc_nginx_rendered_config.stdout"
+      - "'limit_req zone=general' in gencc_nginx_rendered_config.stdout"
+      - "'limit_req zone=search' in gencc_nginx_rendered_config.stdout"
+      - "'limit_conn conn_per_ip 30' in gencc_nginx_rendered_config.stdout"
+      - "'location ^~ /api/pubmed' in gencc_nginx_rendered_config.stdout"
+    fail_msg: "Rendered nginx config is missing expected GenCC hardening directives."
+  when:
+    - gencc_enable_letsencrypt | bool
+    - gencc_le_cert.stat.exists
+
 - name: Enable certbot renewal timer
   ansible.builtin.service:
     name: certbot.timer

--- a/deployment/ansible/roles/nginx_tls/templates/fail2ban/filter-nginx-botsearch.conf.j2
+++ b/deployment/ansible/roles/nginx_tls/templates/fail2ban/filter-nginx-botsearch.conf.j2
@@ -1,0 +1,5 @@
+# {{ ansible_managed }}
+# Matches vulnerability probe paths in the nginx access log.
+[Definition]
+failregex = ^<HOST> - \S+ \[.*\] "(GET|POST|HEAD) /(wp-admin|wp-login|wp-content|\.env|\.git|phpinfo|phpmyadmin|admin\.php|cgi-bin|xmlrpc|actuator|\.aws|vendor/phpunit|telescope/requests|_ignition)
+ignoreregex =

--- a/deployment/ansible/roles/nginx_tls/templates/fail2ban/filter-nginx-forbidden.conf.j2
+++ b/deployment/ansible/roles/nginx_tls/templates/fail2ban/filter-nginx-forbidden.conf.j2
@@ -1,0 +1,7 @@
+# {{ ansible_managed }}
+# Matches 403 responses from bot-blocked requests in the nginx access log.
+# Only triggers when the gencc log format shows bot=1, so legitimate
+# application 403s (authorization failures) are not counted.
+[Definition]
+failregex = ^<HOST> - \S+ \[.*\] "\S+ \S+ \S+" 403 .* bot=1
+ignoreregex =

--- a/deployment/ansible/roles/nginx_tls/templates/fail2ban/filter-nginx-ratelimit.conf.j2
+++ b/deployment/ansible/roles/nginx_tls/templates/fail2ban/filter-nginx-ratelimit.conf.j2
@@ -1,5 +1,7 @@
 # {{ ansible_managed }}
-# Matches nginx rate-limit rejection messages in error.log.
+# Matches nginx error.log rejections from both request-rate limits
+# (limit_req) and per-IP connection limits (limit_conn).
 [Definition]
-failregex = ^\s*\[error\] \d+#\d+: \*\d+ limiting (?:requests|connections), excess: [\d.]+ by zone "\S+", client: <HOST>,
+failregex = ^\s*\[error\] \d+#\d+: \*\d+ limiting requests, excess: [\d.]+ by zone "\S+", client: <HOST>,
+            ^\s*\[error\] \d+#\d+: \*\d+ limiting connections by zone "\S+", client: <HOST>,
 ignoreregex =

--- a/deployment/ansible/roles/nginx_tls/templates/fail2ban/filter-nginx-ratelimit.conf.j2
+++ b/deployment/ansible/roles/nginx_tls/templates/fail2ban/filter-nginx-ratelimit.conf.j2
@@ -1,0 +1,5 @@
+# {{ ansible_managed }}
+# Matches nginx rate-limit rejection messages in error.log.
+[Definition]
+failregex = ^\s*\[error\] \d+#\d+: \*\d+ limiting requests, excess: [\d.]+ by zone "\S+", client: <HOST>,
+ignoreregex =

--- a/deployment/ansible/roles/nginx_tls/templates/fail2ban/filter-nginx-ratelimit.conf.j2
+++ b/deployment/ansible/roles/nginx_tls/templates/fail2ban/filter-nginx-ratelimit.conf.j2
@@ -1,5 +1,5 @@
 # {{ ansible_managed }}
 # Matches nginx rate-limit rejection messages in error.log.
 [Definition]
-failregex = ^\s*\[error\] \d+#\d+: \*\d+ limiting requests, excess: [\d.]+ by zone "\S+", client: <HOST>,
+failregex = ^\s*\[error\] \d+#\d+: \*\d+ limiting (?:requests|connections), excess: [\d.]+ by zone "\S+", client: <HOST>,
 ignoreregex =

--- a/deployment/ansible/roles/nginx_tls/templates/fail2ban/jail.local.j2
+++ b/deployment/ansible/roles/nginx_tls/templates/fail2ban/jail.local.j2
@@ -1,0 +1,44 @@
+# {{ ansible_managed }}
+# fail2ban jail configuration for GenCC nginx deployment.
+
+[DEFAULT]
+# Never ban GCP IAP tunnel IPs (would lock out all SSH users)
+ignoreip = 127.0.0.1/8 ::1 35.235.240.0/20
+backend  = auto
+banaction = iptables-multiport
+
+[sshd]
+enabled  = true
+port     = ssh
+logpath  = /var/log/auth.log
+maxretry = 5
+findtime = 600
+bantime  = 3600
+
+[nginx-req-limit]
+# 50 429s in 10min -> 10min ban
+enabled  = true
+port     = http,https
+filter   = nginx-ratelimit
+logpath  = /var/log/nginx/error.log
+maxretry = 50
+findtime = 600
+bantime  = 600
+
+[nginx-forbidden]
+enabled  = true
+port     = http,https
+filter   = nginx-forbidden
+logpath  = /var/log/nginx/access.log
+maxretry = 5
+findtime = 600
+bantime  = 86400
+
+[nginx-botsearch]
+enabled  = true
+port     = http,https
+filter   = nginx-botsearch
+logpath  = /var/log/nginx/access.log
+maxretry = 3
+findtime = 600
+bantime  = 86400

--- a/deployment/ansible/roles/nginx_tls/templates/fail2ban/jail.local.j2
+++ b/deployment/ansible/roles/nginx_tls/templates/fail2ban/jail.local.j2
@@ -8,6 +8,7 @@ backend  = auto
 banaction = iptables-multiport
 
 [sshd]
+# We have port 22 disabled at the GCP firewall level, so this is just a failsafe
 enabled  = true
 port     = ssh
 logpath  = /var/log/auth.log

--- a/deployment/ansible/roles/nginx_tls/templates/gencc-http.conf.j2
+++ b/deployment/ansible/roles/nginx_tls/templates/gencc-http.conf.j2
@@ -8,12 +8,7 @@ server {
   }
 
   location / {
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
-    proxy_read_timeout 300s;
-    proxy_send_timeout 300s;
+    include /etc/nginx/snippets/gencc-proxy-params.conf;
     proxy_pass http://127.0.0.1:{{ gencc_sub_port }};
   }
 }
@@ -27,12 +22,7 @@ server {
   }
 
   location / {
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
-    proxy_read_timeout 300s;
-    proxy_send_timeout 300s;
+    include /etc/nginx/snippets/gencc-proxy-params.conf;
     proxy_pass http://127.0.0.1:{{ gencc_search_port }};
   }
 }

--- a/deployment/ansible/roles/nginx_tls/templates/gencc-https.conf.j2
+++ b/deployment/ansible/roles/nginx_tls/templates/gencc-https.conf.j2
@@ -12,6 +12,9 @@ server {
   }
 }
 
+# ---------------------------------------------------------------------------
+# gencc-sub (submission portal)
+# ---------------------------------------------------------------------------
 server {
   listen 443 ssl http2;
   server_name {{ gencc_submit_hostname }};
@@ -21,17 +24,57 @@ server {
 
   client_max_body_size 100m;
 
+  access_log /var/log/nginx/access.log gencc;
+  error_log  /var/log/nginx/error.log;
+
+  # -- Security headers ----------------------------------------------------
+  add_header Strict-Transport-Security "max-age={{ gencc_hsts_max_age }}" always;
+  add_header X-Content-Type-Options    "nosniff" always;
+  add_header X-Frame-Options           "SAMEORIGIN" always;
+  add_header Referrer-Policy           "strict-origin-when-cross-origin" always;
+
+  # -- IP blocklist ---------------------------------------------------------
+  include /etc/nginx/snippets/gencc-ip-blocklist.conf;
+
+  # -- Bot blocking (exempt paths handled via map) --------------------------
+  if ($deny_bot) {
+    return 403;
+  }
+
+  # -- Connection limit -----------------------------------------------------
+  limit_conn conn_per_ip 30;
+
+  # -- Health check (no rate limiting) --------------------------------------
+  location = /-/healthz {
+    include /etc/nginx/snippets/gencc-proxy-params.conf;
+    proxy_pass http://127.0.0.1:{{ gencc_sub_port }};
+  }
+
+  # -- Auth endpoints (brute-force protection) ------------------------------
+  location ~ ^/(login|register|forgot-password|reset-password) {
+    limit_req zone=auth burst=3 nodelay;
+
+    include /etc/nginx/snippets/gencc-proxy-params.conf;
+    proxy_pass http://127.0.0.1:{{ gencc_sub_port }};
+  }
+
+  # -- PubMed API (no known consumers — block until needed) -----------------
+  location ^~ /api/pubmed {
+    return 403;
+  }
+
+  # -- Fallback (SPA pages, authenticated routes, external API) -------------
   location / {
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
-    proxy_read_timeout 300s;
-    proxy_send_timeout 300s;
+    limit_req zone=general burst=30 delay=15;
+
+    include /etc/nginx/snippets/gencc-proxy-params.conf;
     proxy_pass http://127.0.0.1:{{ gencc_sub_port }};
   }
 }
 
+# ---------------------------------------------------------------------------
+# gencc-search (public search site)
+# ---------------------------------------------------------------------------
 server {
   listen 443 ssl http2;
   server_name {{ gencc_search_hostname }};
@@ -39,13 +82,54 @@ server {
   ssl_certificate     /etc/letsencrypt/live/{{ gencc_letsencrypt_cert_name }}/fullchain.pem;
   ssl_certificate_key /etc/letsencrypt/live/{{ gencc_letsencrypt_cert_name }}/privkey.pem;
 
+  access_log /var/log/nginx/access.log gencc;
+  error_log  /var/log/nginx/error.log;
+
+  # -- Security headers ----------------------------------------------------
+  add_header Strict-Transport-Security "max-age={{ gencc_hsts_max_age }}" always;
+  add_header X-Content-Type-Options    "nosniff" always;
+  add_header X-Frame-Options           "SAMEORIGIN" always;
+  add_header Referrer-Policy           "strict-origin-when-cross-origin" always;
+
+  # -- IP blocklist ---------------------------------------------------------
+  include /etc/nginx/snippets/gencc-ip-blocklist.conf;
+
+  # -- Bot blocking (exempt paths handled via map) --------------------------
+  if ($deny_bot) {
+    return 403;
+  }
+
+  # -- Connection limit -----------------------------------------------------
+  limit_conn conn_per_ip 30;
+
+  # -- Health check (no rate limiting) --------------------------------------
+  location = /-/healthz {
+    include /etc/nginx/snippets/gencc-proxy-params.conf;
+    proxy_pass http://127.0.0.1:{{ gencc_search_port }};
+  }
+
+  # -- Data exports (heavy queries, tight limits) ---------------------------
+  location ^~ /download/action/ {
+    limit_req  zone=exports burst=2 nodelay;
+    limit_conn conn_per_ip 3;
+
+    include /etc/nginx/snippets/gencc-proxy-params.conf;
+    proxy_pass http://127.0.0.1:{{ gencc_search_port }};
+  }
+
+  # -- Legacy auth pages ----------------------------------------------------
+  location ^~ /gencc-members/ {
+    limit_req zone=auth burst=3 nodelay;
+
+    include /etc/nginx/snippets/gencc-proxy-params.conf;
+    proxy_pass http://127.0.0.1:{{ gencc_search_port }};
+  }
+
+  # -- Fallback (browse pages) ----------------------------------------------
   location / {
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
-    proxy_read_timeout 300s;
-    proxy_send_timeout 300s;
+    limit_req zone=search burst=20 delay=10;
+
+    include /etc/nginx/snippets/gencc-proxy-params.conf;
     proxy_pass http://127.0.0.1:{{ gencc_search_port }};
   }
 }

--- a/deployment/ansible/roles/nginx_tls/templates/gencc-https.conf.j2
+++ b/deployment/ansible/roles/nginx_tls/templates/gencc-https.conf.j2
@@ -58,7 +58,9 @@ server {
     proxy_pass http://127.0.0.1:{{ gencc_sub_port }};
   }
 
-  # -- PubMed API (no known consumers — block until needed) -----------------
+  # -- PubMed API (intentionally blocked at edge) ---------------------------
+  # App routes still exist, but external access stays disabled until a real
+  # consumer is identified.
   location ^~ /api/pubmed {
     return 403;
   }

--- a/deployment/ansible/roles/nginx_tls/templates/gencc-ip-blocklist.conf.j2
+++ b/deployment/ansible/roles/nginx_tls/templates/gencc-ip-blocklist.conf.j2
@@ -1,0 +1,5 @@
+# gencc-ip-blocklist.conf — IP deny list managed via Ansible.
+# Add IPs/CIDRs to the gencc_blocked_ips variable and re-run the playbook.
+{% for ip in gencc_blocked_ips | default([]) %}
+deny {{ ip }};
+{% endfor %}

--- a/deployment/ansible/roles/nginx_tls/templates/gencc-proxy-params.conf.j2
+++ b/deployment/ansible/roles/nginx_tls/templates/gencc-proxy-params.conf.j2
@@ -1,0 +1,6 @@
+proxy_set_header Host $host;
+proxy_set_header X-Real-IP $remote_addr;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Proto $scheme;
+proxy_read_timeout 300s;
+proxy_send_timeout 300s;

--- a/deployment/ansible/roles/nginx_tls/templates/gencc-security.conf.j2
+++ b/deployment/ansible/roles/nginx_tls/templates/gencc-security.conf.j2
@@ -1,0 +1,102 @@
+# gencc-security.conf — http-level security directives
+# Included from /etc/nginx/conf.d/ so it applies to all server blocks.
+
+# ---------------------------------------------------------------------------
+# Rate-limit zones (10m ≈ 160 000 unique IPs)
+# ---------------------------------------------------------------------------
+
+# General page requests (both apps)
+limit_req_zone $binary_remote_addr zone=general:10m     rate=10r/s;
+
+# Search/browse pages (gencc-search)
+limit_req_zone $binary_remote_addr zone=search:10m      rate=8r/s;
+
+# Data exports (gencc-search: /download/action/*) — heavy DB queries
+limit_req_zone $binary_remote_addr zone=exports:5m      rate=2r/m;
+
+# Auth endpoints (login, register, forgot-password, reset-password)
+limit_req_zone $binary_remote_addr zone=auth:5m         rate=5r/m;
+
+limit_req_status 429;
+
+# ---------------------------------------------------------------------------
+# Connection-limit zone
+# ---------------------------------------------------------------------------
+
+limit_conn_zone $binary_remote_addr zone=conn_per_ip:10m;
+limit_conn_status 429;
+
+# ---------------------------------------------------------------------------
+# Bot-blocking maps
+# ---------------------------------------------------------------------------
+
+map $http_user_agent $block_bot {
+    default 0;
+
+    # Empty user agent
+    ""                          1;
+
+    # SEO crawlers
+    ~*SemrushBot                1;
+    ~*AhrefsBot                 1;
+    ~*MJ12bot                   1;
+    ~*DotBot                    1;
+    ~*Barkrowler                1;
+    ~*PetalBot                  1;
+    ~*BLEXBot                   1;
+    ~*DataForSeoBot             1;
+    ~*SeznamBot                 1;
+    ~*Sogou                     1;
+    ~*YandexBot                 1;
+    ~*MegaIndex                 1;
+    ~*BaiduSpider               1;
+
+    # AI training bots
+    ~*ClaudeBot                 1;
+    ~*GPTBot                    1;
+    ~*ChatGPT-User              1;
+    ~*CCBot                     1;
+    ~*Amazonbot                 1;
+    ~*Google-Extended            1;
+    ~*FacebookBot               1;
+    ~*Meta-ExternalAgent         1;
+    ~*anthropic-ai              1;
+    ~*Claude-Web                1;
+    ~*Bytespider                1;
+    ~*Diffbot                   1;
+    ~*Applebot-Extended         1;
+    ~*PerplexityBot             1;
+    ~*Cohere-ai                 1;
+
+    # Vulnerability scanners
+    ~*Nuclei                    1;
+    ~*sqlmap                    1;
+    ~*nikto                     1;
+    ~*Nessus                    1;
+    ~*masscan                   1;
+    ~*ZmEu                      1;
+}
+
+# Paths exempt from bot blocking (downloads, health checks, robots.txt)
+map $request_uri $bot_exempt_path {
+    default                     0;
+    ~^/download/                1;
+    ~^/-/healthz                1;
+    ~^/robots\.txt              1;
+    ~^/favicon\.ico             1;
+}
+
+# Block only when bot detected AND path not exempt
+map "$block_bot:$bot_exempt_path" $deny_bot {
+    default     0;
+    "1:0"       1;
+}
+
+# ---------------------------------------------------------------------------
+# Custom log format with bot flag
+# ---------------------------------------------------------------------------
+
+log_format gencc '$remote_addr - $remote_user [$time_local] '
+                 '"$request" $status $body_bytes_sent '
+                 '"$http_referer" "$http_user_agent" '
+                 'host=$host bot=$block_bot';


### PR DESCRIPTION
## Summary

- **Rate limiting:** Per-IP `limit_req` zones for general pages (10r/s), search (8r/s), data exports (2r/m), and auth endpoints (5r/m). Per-IP connection limits (30 general, 3 for exports).
- **Bot blocking:** User-agent map blocks SEO crawlers, AI training bots, and vulnerability scanners. Download/health-check paths are exempt.
- **IP blocklist:** Ansible-managed `deny` directives via `gencc_blocked_ips` variable.
- **Security headers:** HSTS, X-Content-Type-Options, X-Frame-Options, Referrer-Policy on all responses. HSTS max-age configurable per environment.
- **fail2ban:** Four jails — SSH brute force, repeated 429s, bot-blocked 403s, and vulnerability probe paths (wp-admin, .env, .git, etc.). GCP IAP IPs excluded.
- **Proxy params refactor:** Extracted repeated `proxy_set_header` blocks into a shared snippet.

## Test plan

- [x] Deploy to staging, verify `nginx -t` passes
- [x] Confirm rate limits trigger 429s under load (`ab` or `hey`)
- [x] Confirm bot-blocked user agents get 403
- [x] Confirm download paths are exempt from bot blocking
- [x] Verify fail2ban jails are active (`fail2ban-client status`)
- [x] Verify GCP IAP SSH still works (not banned by fail2ban)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This will be accompanied with file-download-specific cache+throttling in gencc-search
https://github.com/GeneCurationCoalition/gencc-search/issues/187