### PR TITLE
Fix upload validation errors not displaying details

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,5 @@ deployment/terraform/**/.terraform.lock.hcl
 deployment/terraform/**/*.tfstate
 deployment/terraform/**/*.tfstate.backup
 deployment/ansible/gencc-staging-ansible-vault-passphrase.txt
+data/mane_summary.txt
+data/uniprot_sprot_human.dat

--- a/app/Http/Controllers/API/DocumentController.php
+++ b/app/Http/Controllers/API/DocumentController.php
@@ -225,7 +225,8 @@ class DocumentController extends Controller
                 'message' => 'Validation failed',
                 'results' => false,
                 'document_id' => $document->id,
-                'errors' => $validationResult['errors']
+                'errors' => $validationResult['errors'],
+                'warnings' => $validationResult['warnings'] ?? []
             ], 422);
         }
 
@@ -514,23 +515,47 @@ class DocumentController extends Controller
 
         if (!empty($validation_errors)) {
             // Separate blocking errors from warnings
-            $errors = array_filter($validation_errors, fn($e) => ($e['severity'] ?? 'error') !== 'warning');
-            $warnings = array_filter($validation_errors, fn($e) => ($e['severity'] ?? 'error') === 'warning');
+            // array_values() reindexes to ensure JSON serializes as array, not object
+            $errors = array_values(array_filter($validation_errors, fn($e) => ($e['severity'] ?? 'error') !== 'warning'));
+            $warnings = array_values(array_filter($validation_errors, fn($e) => ($e['severity'] ?? 'error') === 'warning'));
 
             if (!empty($errors)) {
                 $formattedErrors = array_map(function($error) {
                     $rows = $error['rows'] ?? ($error['row'] ?? 'N/A');
-                    return [
+                    $formatted = [
                         'error_type' => $error['error_type'] ?? 'validation_error',
                         'severity' => $error['severity'] ?? 'error',
                         'message' => $error['message'] ?? 'Unknown validation error',
                         'rows' => $rows,
                     ];
+
+                    // Preserve column name for frontend grouping
+                    if (!empty($error['column'])) {
+                        $formatted['column'] = $error['column'];
+                    }
+
+                    // Preserve expandable details (unique values with their rows)
+                    if (!empty($error['details'])) {
+                        $formatted['details'] = $error['details'];
+                    }
+
+                    // Preserve file format error fields for frontend display
+                    if (!empty($error['is_file_format_error'])) {
+                        $formatted['is_file_format_error'] = true;
+                    }
+                    if (!empty($error['user_title'])) {
+                        $formatted['user_title'] = $error['user_title'];
+                    }
+                    if (!empty($error['user_message'])) {
+                        $formatted['user_message'] = $error['user_message'];
+                    }
+
+                    return $formatted;
                 }, $errors);
 
                 return [
                     'has_errors' => true,
-                    'errors' => $formattedErrors,
+                    'errors' => array_values($formattedErrors),
                     'warnings' => array_values(array_map(function($w) {
                         return [
                             'error_type' => $w['error_type'] ?? 'warning',

--- a/app/Services/SubmissionFileValidation.php
+++ b/app/Services/SubmissionFileValidation.php
@@ -324,57 +324,122 @@ class SubmissionFileValidation
     }
 
     /**
-     * Group validation errors by message and collect rows that have each error
+     * Group validation errors by error_type + column (coarse grouping) and collect
+     * unique values with their rows as expandable details.
+     *
+     * For errors with a 'column' field (field-level validation), groups by error_type + column
+     * so all "invalid disease_id" errors become one group with details per unique value.
+     *
+     * For errors without a 'column' field (structural errors, duplicates, etc.),
+     * groups by exact message as before.
      *
      * @param array $validation_results Raw validation results (one per row)
-     * @return array Grouped validation results (one per unique message with comma-separated rows)
+     * @return array Grouped validation results with optional 'details' for expansion
      */
     private static function group_validation_errors(array $validation_results): array
     {
         $grouped = [];
 
         foreach ($validation_results as $error) {
-            // Skip errors that don't have a message or row (like fatal errors)
+            // Skip errors that don't have a message (like fatal errors without context)
             if (!isset($error['message'])) {
                 $grouped[] = $error;
                 continue;
             }
 
-            $message = $error['message'];
-
-            // Create a key that includes message and other identifying info (but not row)
-            $key = md5($message . ($error['error_type'] ?? '') . ($error['severity'] ?? ''));
-
-            if (!isset($grouped[$key])) {
-                // First occurrence of this error - create new entry
-                $grouped[$key] = $error;
-                $grouped[$key]['rows'] = [];
+            // Determine grouping key:
+            // - Field-level errors (with 'column'): group by error_type + column
+            // - Other errors: group by exact message
+            if (!empty($error['column'])) {
+                $key = ($error['error_type'] ?? 'error') . ':' . $error['column'];
+            } else {
+                $key = md5($error['message'] . ($error['error_type'] ?? '') . ($error['severity'] ?? ''));
             }
 
-            // Add row number to the list if it exists
+            if (!isset($grouped[$key])) {
+                $grouped[$key] = [
+                    'error_type' => $error['error_type'] ?? 'validation_error',
+                    'severity' => $error['severity'] ?? 'error',
+                    'validation_type' => $error['validation_type'] ?? null,
+                    'column' => $error['column'] ?? null,
+                    'rows' => [],
+                    '_values' => [],  // temporary: collect value → rows mapping
+                ];
+
+                // For non-column errors, keep the original message
+                if (empty($error['column'])) {
+                    $grouped[$key]['message'] = $error['message'];
+                }
+
+                // Preserve file format error fields
+                if (!empty($error['is_file_format_error'])) {
+                    $grouped[$key]['is_file_format_error'] = $error['is_file_format_error'];
+                    $grouped[$key]['user_title'] = $error['user_title'] ?? null;
+                    $grouped[$key]['user_message'] = $error['user_message'] ?? null;
+                }
+            }
+
+            // Add row number
             if (isset($error['row'])) {
                 $grouped[$key]['rows'][] = $error['row'];
             }
+
+            // Track unique values for column-level errors
+            if (!empty($error['value'])) {
+                $val = $error['value'];
+                if (!isset($grouped[$key]['_values'][$val])) {
+                    $grouped[$key]['_values'][$val] = [];
+                }
+                if (isset($error['row'])) {
+                    $grouped[$key]['_values'][$val][] = $error['row'];
+                }
+            }
         }
 
-        // Convert rows arrays to comma-separated strings
+        // Finalize grouped results
         $result = [];
         foreach ($grouped as $error) {
-            if (isset($error['rows']) && !empty($error['rows'])) {
-                // Sort row numbers
+            // Sort and format rows
+            if (!empty($error['rows'])) {
                 sort($error['rows'], SORT_NUMERIC);
-
-                // Keep rows as comma-separated string for frontend use
+                $rowCount = count($error['rows']);
                 $error['rows'] = implode(', ', $error['rows']);
-
-                // Remove row-specific fields from grouped output
-                unset($error['row']);
-                unset($error['sgc_id']);
-                unset($error['local_key']);
             } else {
-                // No rows to display
+                $rowCount = 0;
                 $error['rows'] = '';
             }
+
+            // Build summary message and details for column-level errors
+            if (!empty($error['column'])) {
+                $column = $error['column'];
+                $guidance = self::get_column_guidance($column);
+                $errorVerb = ($error['error_type'] === 'invalid_field_format') ? 'Invalid format' : 'Invalid value';
+                $error['message'] = "{$errorVerb} for column '{$column}' ({$rowCount} row" . ($rowCount !== 1 ? 's' : '') . "). {$guidance}";
+
+                // Build details array from unique values
+                if (!empty($error['_values'])) {
+                    $details = [];
+                    foreach ($error['_values'] as $value => $valueRows) {
+                        sort($valueRows, SORT_NUMERIC);
+                        $details[] = [
+                            'value' => $value,
+                            'rows' => implode(', ', $valueRows),
+                            'count' => count($valueRows),
+                        ];
+                    }
+                    // Sort details by count descending (most common first)
+                    usort($details, fn($a, $b) => $b['count'] - $a['count']);
+                    $error['details'] = $details;
+                }
+            }
+
+            // Clean up temporary and row-specific fields
+            unset($error['_values']);
+            unset($error['row']);
+            unset($error['sgc_id']);
+            unset($error['local_key']);
+            unset($error['value']);
+
             $result[] = $error;
         }
 
@@ -772,14 +837,17 @@ class SubmissionFileValidation
                 $normalized_value = preg_replace('/\s+/u', ' ', trim($value));
                 if (!preg_match($regexp, $normalized_value)) {
                     $guidance = self::get_column_guidance($column_name);
+                    $truncated_value = mb_strlen($normalized_value) > 80 ? mb_substr($normalized_value, 0, 80) . '...' : $normalized_value;
                     $validation_results[] = [
                         'error_type' => 'invalid_field_format',
                         'severity' => self::SEVERITY_ERROR,
                         'validation_type' => self::DATA_VALIDATION,
                         'row' => $row_num,
+                        'column' => $column_name,
+                        'value' => $truncated_value,
                         'sgc_id' => $sgc_id,
                         'local_key' => $local_key,
-                        'message' => "Invalid format for column '{$column_name}'. {$guidance}",
+                        'message' => "Invalid format for column '{$column_name}': '{$truncated_value}'. {$guidance}",
                     ];
                     $field_validation_failed = true;  // Stop further validation for this field
                 }
@@ -791,14 +859,17 @@ class SubmissionFileValidation
                 $valid_values = call_user_func($validator_method);
                 if (!in_array($value, $valid_values)) {
                     $guidance = self::get_column_guidance($column_name);
+                    $truncated_value = mb_strlen($value) > 80 ? mb_substr($value, 0, 80) . '...' : $value;
                     $validation_results[] = [
                         'error_type' => 'invalid_field_value',
                         'severity' => self::SEVERITY_ERROR,
                         'validation_type' => self::DATA_VALIDATION,
                         'row' => $row_num,
+                        'column' => $column_name,
+                        'value' => $truncated_value,
                         'sgc_id' => $sgc_id,
                         'local_key' => $local_key,
-                        'message' => "Invalid value for column '{$column_name}'. {$guidance}",
+                        'message' => "Invalid value for column '{$column_name}': '{$truncated_value}'. {$guidance}",
                     ];
                     $field_validation_failed = true;  // Stop further validation for this field
                 }
@@ -810,14 +881,17 @@ class SubmissionFileValidation
                 $return = call_user_func($validator_method, $value);
                 if ($return === null ) {
                     $guidance = self::get_column_guidance($column_name);
+                    $truncated_value = mb_strlen($value) > 80 ? mb_substr($value, 0, 80) . '...' : $value;
                     $validation_results[] = [
                         'error_type' => 'invalid_field_value',
                         'severity' => self::SEVERITY_ERROR,
                         'validation_type' => self::DATA_VALIDATION,
                         'row' => $row_num,
+                        'column' => $column_name,
+                        'value' => $truncated_value,
                         'sgc_id' => $sgc_id,
                         'local_key' => $local_key,
-                        'message' => "Invalid value for column '{$column_name}'. {$guidance}",
+                        'message' => "Invalid value for column '{$column_name}': '{$truncated_value}'. {$guidance}",
                     ];
                     // No need to set flag here as this is the last check
                 }

--- a/resources/js/Components/JobItem.vue
+++ b/resources/js/Components/JobItem.vue
@@ -24,6 +24,7 @@ const confirm = useConfirm();
 const uploadErrors = ref([]);
 const uploadWarnings = ref([]);
 const showErrorCard = ref(false);
+const expandedDetailRows = ref({});
 const uploadedFilename = ref('');
 const uploadedDocumentId = ref(null);
 const uploadedFileSize = ref(0);
@@ -205,8 +206,11 @@ const fileFormatErrors = computed(() => {
 });
 
 // Data row errors are displayed in the table format
+// __index is added for DataTable's dataKey (needed for row expansion)
 const dataRowErrors = computed(() => {
-    return uploadErrors.value.filter(err => !isFileFormatError(err));
+    return uploadErrors.value
+        .filter(err => !isFileFormatError(err))
+        .map((err, idx) => ({ ...err, __index: idx }));
 });
 
 // Computed: PMID normalization warnings
@@ -317,6 +321,7 @@ const displayErrorCard = (errors) => {
   if (actualErrors.length > 0) {
     showErrorCard.value = true; // Default to expanded when errors first appear
     expandedErrorRows.value = {}; // Reset expanded state when showing new errors
+    expandedDetailRows.value = {}; // Reset detail expansion state
   } else if (warnings.length > 0) {
     console.log('Validation passed with warnings:', warnings);
   } else {
@@ -371,17 +376,26 @@ const formatRowsForDisplay = (rowsString, index) => {
 };
 
 const downloadErrors = () => {
-  const headers = 'Error Type,Severity,Message,Rows\n';
-  const rows = uploadErrors.value.map(error => {
+  const headers = 'Error Type,Severity,Column,Message,Value,Rows\n';
+  const csvRows = [];
+
+  uploadErrors.value.forEach(error => {
     const errorType = error.error_type || 'validation_error';
     const severity = error.severity || 'error';
+    const column = error.column || '';
     const message = error.message || '';
-    const rowsList = error.rows || '';
 
-    return `"${errorType}","${severity}","${message.replace(/"/g, '""')}","${rowsList}"`;
-  }).join('\n');
+    // If error has details (grouped with unique values), output one row per detail
+    if (error.details && error.details.length > 0) {
+      error.details.forEach(detail => {
+        csvRows.push(`"${errorType}","${severity}","${column}","${message.replace(/"/g, '""')}","${(detail.value || '').replace(/"/g, '""')}","${detail.rows}"`);
+      });
+    } else {
+      csvRows.push(`"${errorType}","${severity}","${column}","${message.replace(/"/g, '""')}","","${error.rows || ''}"`);
+    }
+  });
 
-  const csvContent = headers + rows;
+  const csvContent = headers + csvRows.join('\n');
   const blob = new Blob([csvContent], { type: 'text/csv' });
   const url = window.URL.createObjectURL(blob);
   const a = document.createElement('a');
@@ -1311,11 +1325,15 @@ const formatDate = (dateString) => {
                             </p>
                         </div>
                         <DataTable :value="dataRowErrors"
+                                   v-model:expandedRows="expandedDetailRows"
+                                   dataKey="__index"
                                    size="small"
                                    stripedRows
                                    scrollable
                                    scrollHeight="400px"
                                    class="text-sm">
+                            <Column :expander="true" :style="{width: '40px'}"
+                                    v-if="dataRowErrors.some(e => e.details && e.details.length > 0)" />
                             <Column field="error_type" header="Error Type" :style="{width: '180px'}">
                                 <template #body="slotProps">
                                     <span class="font-mono text-xs">{{ slotProps.data.error_type || 'validation_error' }}</span>
@@ -1351,6 +1369,30 @@ const formatDate = (dateString) => {
                                     </div>
                                 </template>
                             </Column>
+                            <template #expansion="slotProps">
+                                <div class="p-3 bg-gray-50">
+                                    <div class="text-xs font-semibold text-gray-600 mb-2">
+                                        {{ slotProps.data.details.length }} distinct value(s) found:
+                                    </div>
+                                    <table class="w-full text-xs">
+                                        <thead>
+                                            <tr class="border-b border-gray-200">
+                                                <th class="text-left py-1 pr-4 text-gray-500 font-medium">Value</th>
+                                                <th class="text-left py-1 pr-4 text-gray-500 font-medium">Count</th>
+                                                <th class="text-left py-1 text-gray-500 font-medium">Rows</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            <tr v-for="(detail, dIdx) in slotProps.data.details" :key="dIdx"
+                                                class="border-b border-gray-100 last:border-b-0">
+                                                <td class="py-1 pr-4 font-mono text-red-700">{{ detail.value }}</td>
+                                                <td class="py-1 pr-4 text-gray-600">{{ detail.count }}</td>
+                                                <td class="py-1 font-mono text-gray-500">{{ detail.rows }}</td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </template>
                         </DataTable>
                     </div>
                 </template>

--- a/tests/Unit/SubmissionFileValidationTest.php
+++ b/tests/Unit/SubmissionFileValidationTest.php
@@ -892,4 +892,221 @@ class SubmissionFileValidationTest extends TestCase
 
         $this->assertEmpty($geneChangeErrors, 'HGNC prefix comparison should be case-insensitive');
     }
+
+    // =========================================================================
+    // Error Grouping & Detail Tests
+    // =========================================================================
+
+    /**
+     * Test: Field-level errors include column and value fields
+     */
+    public function test_field_errors_include_column_and_value(): void
+    {
+        $row = $this->createValidDataRow(['hgnc_id' => 'INVALID']);
+
+        $errors = SubmissionFileValidation::validate_data_row($row, 13);
+
+        $formatError = collect($errors)->firstWhere('error_type', 'invalid_field_format');
+        $this->assertNotNull($formatError, 'Should have invalid_field_format error');
+        $this->assertEquals('hgnc_id', $formatError['column']);
+        $this->assertEquals('INVALID', $formatError['value']);
+        $this->assertStringContainsString('INVALID', $formatError['message']);
+    }
+
+    /**
+     * Test: Enum validation errors include column and value
+     */
+    public function test_enum_errors_include_column_and_value(): void
+    {
+        $row = $this->createValidDataRow(['classification_id' => 'GENCC:999999']);
+
+        $errors = SubmissionFileValidation::validate_data_row($row, 13);
+
+        $valueError = collect($errors)->first(fn($e) => ($e['error_type'] ?? '') === 'invalid_field_value' && ($e['column'] ?? '') === 'classification_id');
+        $this->assertNotNull($valueError, 'Should have invalid_field_value error for classification_id');
+        $this->assertEquals('classification_id', $valueError['column']);
+        $this->assertEquals('GENCC:999999', $valueError['value']);
+        $this->assertStringContainsString('GENCC:999999', $valueError['message']);
+    }
+
+    /**
+     * Test: Database lookup errors include column and value
+     */
+    public function test_database_lookup_errors_include_column_and_value(): void
+    {
+        $row = $this->createValidDataRow(['disease_id' => 'MONDO:9999999']);
+
+        $errors = SubmissionFileValidation::validate_data_row($row, 13);
+
+        $valueError = collect($errors)->firstWhere('error_type', 'invalid_field_value');
+        $this->assertNotNull($valueError, 'Should have invalid_field_value error for unknown disease');
+        $this->assertEquals('disease_id', $valueError['column']);
+        $this->assertEquals('MONDO:9999999', $valueError['value']);
+    }
+
+    /**
+     * Test: Long values are truncated to 80 characters
+     */
+    public function test_long_values_are_truncated(): void
+    {
+        $longValue = str_repeat('x', 120);
+        $row = $this->createValidDataRow(['assertion_criteria_url' => $longValue]);
+
+        $errors = SubmissionFileValidation::validate_data_row($row, 13);
+
+        $formatError = collect($errors)->firstWhere('column', 'assertion_criteria_url');
+        $this->assertNotNull($formatError);
+        $this->assertEquals(83, mb_strlen($formatError['value'])); // 80 + '...'
+        $this->assertStringEndsWith('...', $formatError['value']);
+    }
+
+    /**
+     * Test: Errors with same column are grouped together in validate_spreadsheet
+     */
+    public function test_errors_grouped_by_column(): void
+    {
+        $worksheet = $this->createValidSpreadsheet([
+            $this->createValidDataRow(['disease_id' => 'MONDO:9999999']),
+            $this->createValidDataRow(['disease_id' => 'MONDO:8888888', 'local_key' => 'TEST002']),
+        ]);
+
+        SubmissionFileValidation::set_submitter_id($this->testSubmitter->id);
+        $errors = SubmissionFileValidation::validate_spreadsheet($worksheet, $this->testSubmitter->id, true);
+
+        // Filter to just disease_id errors
+        $diseaseErrors = collect($errors)->filter(fn($e) => ($e['column'] ?? null) === 'disease_id');
+
+        // Should be grouped into one entry (not two separate ones)
+        $this->assertCount(1, $diseaseErrors, 'Disease ID errors should be grouped into one entry');
+
+        $grouped = $diseaseErrors->first();
+        $this->assertStringContainsString('2 rows', $grouped['message']);
+        $this->assertArrayHasKey('details', $grouped);
+        $this->assertCount(2, $grouped['details']); // Two distinct values
+    }
+
+    /**
+     * Test: Grouped errors have details with value, rows, and count
+     */
+    public function test_grouped_errors_have_details_structure(): void
+    {
+        $worksheet = $this->createValidSpreadsheet([
+            $this->createValidDataRow(['disease_id' => 'MONDO:9999999']),
+            $this->createValidDataRow(['disease_id' => 'MONDO:9999999', 'local_key' => 'TEST002']),
+            $this->createValidDataRow(['disease_id' => 'MONDO:8888888', 'local_key' => 'TEST003']),
+        ]);
+
+        SubmissionFileValidation::set_submitter_id($this->testSubmitter->id);
+        $errors = SubmissionFileValidation::validate_spreadsheet($worksheet, $this->testSubmitter->id, true);
+
+        $diseaseError = collect($errors)->firstWhere('column', 'disease_id');
+        $this->assertNotNull($diseaseError);
+
+        // 3 total rows
+        $this->assertStringContainsString('3 rows', $diseaseError['message']);
+
+        // Details sorted by count descending
+        $this->assertCount(2, $diseaseError['details']);
+        $this->assertEquals(2, $diseaseError['details'][0]['count']); // MONDO:9999999 appears twice
+        $this->assertEquals(1, $diseaseError['details'][1]['count']); // MONDO:8888888 appears once
+
+        // Each detail has required fields
+        foreach ($diseaseError['details'] as $detail) {
+            $this->assertArrayHasKey('value', $detail);
+            $this->assertArrayHasKey('rows', $detail);
+            $this->assertArrayHasKey('count', $detail);
+        }
+    }
+
+    /**
+     * Test: Non-column errors (like duplicates) still group by message
+     */
+    public function test_non_column_errors_group_by_message(): void
+    {
+        $worksheet = $this->createValidSpreadsheet([
+            $this->createValidDataRow([
+                'action' => 'R',
+                'sgc_id' => 'SGC-100001'
+            ]),
+            $this->createValidDataRow([
+                'action' => 'R',
+                'sgc_id' => 'SGC-100001'
+            ])
+        ]);
+
+        SubmissionFileValidation::set_submitter_id($this->testSubmitter->id);
+        $errors = SubmissionFileValidation::validate_spreadsheet($worksheet, $this->testSubmitter->id, true);
+
+        // duplicate_sgc_id errors should be grouped (same message, no column field)
+        $dupErrors = collect($errors)->where('error_type', 'duplicate_sgc_id');
+        $this->assertCount(1, $dupErrors, 'Duplicate SGC ID errors should be grouped into one entry');
+
+        $grouped = $dupErrors->first();
+        $this->assertStringContainsString('13, 14', $grouped['rows']);
+        $this->assertNull($grouped['column'] ?? null);
+        $this->assertArrayNotHasKey('details', $grouped);
+    }
+
+    /**
+     * Test: Grouped errors do not leak internal fields (sgc_id, local_key, _values)
+     */
+    public function test_grouped_errors_clean_internal_fields(): void
+    {
+        $worksheet = $this->createValidSpreadsheet([
+            $this->createValidDataRow(['hgnc_id' => 'INVALID']),
+        ]);
+
+        SubmissionFileValidation::set_submitter_id($this->testSubmitter->id);
+        $errors = SubmissionFileValidation::validate_spreadsheet($worksheet, $this->testSubmitter->id, true);
+
+        foreach ($errors as $error) {
+            $this->assertArrayNotHasKey('_values', $error, 'Internal _values should be removed');
+            $this->assertArrayNotHasKey('sgc_id', $error, 'sgc_id should be removed from grouped errors');
+            $this->assertArrayNotHasKey('local_key', $error, 'local_key should be removed from grouped errors');
+            $this->assertArrayNotHasKey('row', $error, 'Individual row field should be removed (rows string used instead)');
+        }
+    }
+
+    /**
+     * Test: File format errors preserve is_file_format_error, user_title, user_message
+     */
+    public function test_file_format_errors_preserve_user_fields(): void
+    {
+        $worksheet = [];
+        for ($i = 0; $i < 5; $i++) {
+            $worksheet[] = array_fill(0, 18, '');
+        }
+        // Invalid headers
+        $worksheet[] = ['wrong_col_1', 'wrong_col_2'];
+        for ($i = 0; $i < 6; $i++) {
+            $worksheet[] = array_fill(0, 18, '');
+        }
+        $worksheet[] = $this->createValidDataRow();
+
+        SubmissionFileValidation::set_submitter_id($this->testSubmitter->id);
+        $errors = SubmissionFileValidation::validate_spreadsheet($worksheet, $this->testSubmitter->id, true);
+
+        $this->assertNotEmpty($errors);
+        $this->assertTrue($errors[0]['is_file_format_error'] ?? false);
+        $this->assertNotEmpty($errors[0]['user_title'] ?? '');
+        $this->assertNotEmpty($errors[0]['user_message'] ?? '');
+    }
+
+    /**
+     * Test: Single row error still gets grouped summary with "1 row"
+     */
+    public function test_single_row_error_grouped_with_singular_count(): void
+    {
+        $worksheet = $this->createValidSpreadsheet([
+            $this->createValidDataRow(['hgnc_id' => 'INVALID']),
+        ]);
+
+        SubmissionFileValidation::set_submitter_id($this->testSubmitter->id);
+        $errors = SubmissionFileValidation::validate_spreadsheet($worksheet, $this->testSubmitter->id, true);
+
+        $hgncError = collect($errors)->firstWhere('column', 'hgnc_id');
+        $this->assertNotNull($hgncError);
+        $this->assertStringContainsString('1 row)', $hgncError['message']);
+        $this->assertStringNotContainsString('1 rows', $hgncError['message']);
+    }
 }


### PR DESCRIPTION
## Summary
- **Fix JSON serialization bug**: `array_filter()` preserves keys producing non-contiguous indices that serialize as JSON objects instead of arrays, causing the frontend `Array.isArray()` check to fail silently — wrapped with `array_values()` to reindex
- **Preserve error metadata**: Pass through `column`, `details`, `user_title`, `user_message`, and `is_file_format_error` fields in the error formatter so the frontend can render actionable messages
- **Add warnings to 422 response**: Include separated warnings array alongside errors
- **Add grouped error display**: Field-level errors are collapsed by error type + column with expandable details showing distinct invalid values and affected rows, supporting files with thousands of errors
- **Add unit tests**: 10 new test methods covering column/value fields, value truncation, error grouping, detail structure, and file format error preservation (34 tests total, all passing)

## Files changed
| File | Change |
|------|--------|
| `app/Http/Controllers/API/DocumentController.php` | Fix `array_values()` reindexing, preserve error metadata fields, add warnings to response |
| `app/Services/SubmissionFileValidation.php` | Add `column`/`value` to field errors, rewrite `group_validation_errors()` for collapse grouping |
| `resources/js/Components/JobItem.vue` | Add PrimeVue DataTable row expansion for grouped error details, update CSV download |
| `tests/Unit/SubmissionFileValidationTest.php` | Add 10 new test methods for validation changes |
| `.gitignore` | Ignore local data files |

## Test plan
- [x] All 34 unit tests pass (87 assertions)
- [ ] Upload a submission file with known validation errors and verify error details are displayed
- [ ] Verify grouped errors can be expanded to show distinct values and row numbers
- [ ] Verify file format errors (e.g., wrong headers) show user-friendly messages
- [ ] Verify CSV download includes column and value details

🤖 Generated with [Claude Code](https://claude.com/claude-code)