### PR TITLE
Fix upload processing errors and improve disease ID validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ deployment/terraform/**/*.tfstate.backup
 deployment/ansible/gencc-staging-ansible-vault-passphrase.txt
 data/mane_summary.txt
 data/uniprot_sprot_human.dat
+deployment/ansible/gencc-prod-ansible-vault-passphrase.txt

--- a/app/Console/Commands/UpdateOmim.php
+++ b/app/Console/Commands/UpdateOmim.php
@@ -202,7 +202,7 @@ class UpdateOmim extends Command
                         if ($phenotype['key'] != 3)
                             continue;
 
-                        $disease = Disease::rosetta($phenotype['mim']);
+                        $disease = Disease::rosetta('OMIM:' . $phenotype['mim']);
 
                         if ($disease === null)
                             continue;

--- a/app/Http/Controllers/API/DocumentController.php
+++ b/app/Http/Controllers/API/DocumentController.php
@@ -845,12 +845,12 @@ class DocumentController extends Controller
             // Debug logging disabled for performance - uncomment if needed
             // \Log::info("Row: " . $rownum . " Contents: " . $row);
 
+            // Trim all cell values to remove leading/trailing whitespace, tabs, and newlines
+            $row = $row->map(fn($value) => is_string($value) ? trim($value) : $value);
+
             // do not process blank lines
             if (empty(implode('', $row->toArray())))
                 continue;
-
-            // Trim all cell values to remove leading/trailing whitespace, tabs, and newlines
-            $row = $row->map(fn($value) => is_string($value) ? trim($value) : $value);
 
             $processedRows++;
 

--- a/app/Http/Controllers/API/DocumentController.php
+++ b/app/Http/Controllers/API/DocumentController.php
@@ -849,6 +849,9 @@ class DocumentController extends Controller
             if (empty(implode('', $row->toArray())))
                 continue;
 
+            // Trim all cell values to remove leading/trailing whitespace, tabs, and newlines
+            $row = $row->map(fn($value) => is_string($value) ? trim($value) : $value);
+
             $processedRows++;
 
             // Check wall-clock timeout (measures real time, not just CPU time)
@@ -1135,9 +1138,14 @@ class DocumentController extends Controller
                     ];
                     SpreadsheetUpdate::dispatch((object) $message);
                     $job->addEvent('SGC ID ' . $submission->sid . ' encountered submission errors');
-                    $job->update(['status' => Job::STATUS_ERRORS]);
                     $submission->submission_errors = $status;
                     // Errors are determined by submission_errors via has_errors accessor
+                    // Set draft status so the submission is editable/deletable in the UI
+                    if ($action === 'R') {
+                        $submission->status = Submission::STATUS_DRAFT_REPUBLISH;
+                    } elseif ($action === 'N') {
+                        $submission->status = Submission::STATUS_DRAFT_NEW;
+                    }
                     $submission->user_id = $document->user_id;
                     $submission->document_id = $document->id;
                     $job->submissions()->save($submission);

--- a/app/Http/Controllers/API/SubmitController.php
+++ b/app/Http/Controllers/API/SubmitController.php
@@ -133,7 +133,7 @@ class SubmitController extends Controller
                     }
                     else
                     {
-                        $job->addEvent('SID $submision->sid encountered submission errors');
+                        $job->addEvent('SID ' . $submission->sid . ' encountered submission errors');
                         $submission->submission_errors = $status;
                         // Errors are determined by submission_errors via has_errors accessor
                         $job->submissions()->save($submission);

--- a/app/Http/Controllers/API/SubmitController.php
+++ b/app/Http/Controllers/API/SubmitController.php
@@ -134,7 +134,6 @@ class SubmitController extends Controller
                     else
                     {
                         $job->addEvent('SID $submision->sid encountered submission errors');
-                        $job->update(['status' => Job::STATUS_ERRORS]);
                         $submission->submission_errors = $status;
                         // Errors are determined by submission_errors via has_errors accessor
                         $job->submissions()->save($submission);

--- a/app/Models/Disease.php
+++ b/app/Models/Disease.php
@@ -299,6 +299,53 @@ class Disease extends Model
 
 
     /**
+     * Stricter validation for submissions — ensures the MONDO mapping is
+     * discoverable via xrefs (the same path the Phase 2 processing cache uses).
+     *
+     * For OMIM IDs, rosetta() may find a MONDO record via the mondo_id FK on the
+     * OMIM record, but if the MONDO record doesn't list that OMIM ID in its xrefs,
+     * the Phase 2 cache won't find it either.  This method rejects those cases so
+     * Phase 1 validation is consistent with Phase 2 processing.
+     *
+     * @param string $id The disease identifier (with or without prefix)
+     * @return Disease|null The MONDO disease record, or null if not resolvable via xrefs
+     */
+    public static function rosettaForSubmission($id): ?Disease
+    {
+        $result = self::rosetta($id);
+        if ($result === null) {
+            return null;
+        }
+
+        // Only OMIM IDs need the extra xref check — MONDO/Orphanet map directly
+        $normalized = trim($id);
+        $parts = explode(':', $normalized);
+        if (isset($parts[1])) {
+            $prefix = strtoupper($parts[0]);
+            $number = $parts[1];
+        } elseif (is_numeric($normalized)) {
+            $prefix = 'OMIM';
+            $number = $normalized;
+        } else {
+            return $result;
+        }
+
+        if (!in_array($prefix, ['OMIM', 'OMIMPS'])) {
+            return $result;
+        }
+
+        // Verify the MONDO record's xrefs contain this OMIM number
+        $xrefOmimIds = $result->xrefs->omim_id ?? null;
+        if ($xrefOmimIds === null) {
+            return null;
+        }
+        $xrefOmimIds = is_array($xrefOmimIds) ? $xrefOmimIds : [$xrefOmimIds];
+
+        return in_array($number, $xrefOmimIds) ? $result : null;
+    }
+
+
+    /**
      * Resolve an OMIM ID to its canonical MONDO disease
      *
      * @param string $curie OMIM CURIE (e.g., "OMIM:615438")

--- a/app/Models/Disease.php
+++ b/app/Models/Disease.php
@@ -226,18 +226,13 @@ class Disease extends Model
         if (empty($id))
             return null;
 
-        // Separate out prefix and identifier
+        // Separate out prefix and identifier — requires CURIE format (PREFIX:ID)
         $parts = explode(':', basename(trim($id)));
 
-        // If a prefix is omitted, assume it is a MIM number
+        // Reject bare values without a prefix — callers must supply a proper CURIE
         if (!isset($parts[1]))
         {
-            if (is_numeric($id)) {
-                $curie = 'OMIM:' . $id;
-                $record = self::rosettaOmim($curie);
-            } else {
-                $record = null;
-            }
+            return null;
         }
         else
         {
@@ -307,7 +302,7 @@ class Disease extends Model
      * the Phase 2 cache won't find it either.  This method rejects those cases so
      * Phase 1 validation is consistent with Phase 2 processing.
      *
-     * @param string $id The disease identifier (with or without prefix)
+     * @param string $id The disease identifier in CURIE format (PREFIX:ID)
      * @return Disease|null The MONDO disease record, or null if not resolvable via xrefs
      */
     public static function rosettaForSubmission($id): ?Disease
@@ -320,15 +315,11 @@ class Disease extends Model
         // Only OMIM IDs need the extra xref check — MONDO/Orphanet map directly
         $normalized = trim($id);
         $parts = explode(':', $normalized);
-        if (isset($parts[1])) {
-            $prefix = strtoupper($parts[0]);
-            $number = $parts[1];
-        } elseif (is_numeric($normalized)) {
-            $prefix = 'OMIM';
-            $number = $normalized;
-        } else {
-            return $result;
+        if (!isset($parts[1])) {
+            return null;
         }
+        $prefix = strtoupper($parts[0]);
+        $number = $parts[1];
 
         if (!in_array($prefix, ['OMIM', 'OMIMPS'])) {
             return $result;

--- a/app/Services/SubmissionFileValidation.php
+++ b/app/Services/SubmissionFileValidation.php
@@ -88,8 +88,8 @@ class SubmissionFileValidation
             # MONDO:#####, OMIM:#### or ORPHA:######/Orphanet:######
             'regexp' => '/^(\d+|(MONDO|OMIM|ORPHA|Orphanet):\d+)$/i',
             'validator_with_argument' => [
-                'method' => [Disease::class, 'rosetta'],
-                'message' => 'Invalid Disease ID',
+                'method' => [Disease::class, 'rosettaForSubmission'],
+                'message' => 'No MONDO associated disease value for submitted OMIM or ORPHA disease id',
             ],
         ],
         'disease_name' => [
@@ -371,6 +371,11 @@ class SubmissionFileValidation
                     $grouped[$key]['message'] = $error['message'];
                 }
 
+                // Preserve custom group message from validator_with_argument
+                if (!empty($error['group_message'])) {
+                    $grouped[$key]['_group_message'] = $error['group_message'];
+                }
+
                 // Preserve file format error fields
                 if (!empty($error['is_file_format_error'])) {
                     $grouped[$key]['is_file_format_error'] = $error['is_file_format_error'];
@@ -412,9 +417,14 @@ class SubmissionFileValidation
             // Build summary message and details for column-level errors
             if (!empty($error['column'])) {
                 $column = $error['column'];
-                $guidance = self::get_column_guidance($column);
-                $errorVerb = ($error['error_type'] === 'invalid_field_format') ? 'Invalid format' : 'Invalid value';
-                $error['message'] = "{$errorVerb} for column '{$column}' ({$rowCount} row" . ($rowCount !== 1 ? 's' : '') . "). {$guidance}";
+                $rowLabel = $rowCount !== 1 ? "{$rowCount} rows" : "1 row";
+                if (!empty($error['_group_message'])) {
+                    $error['message'] = "{$error['_group_message']} ({$rowLabel}).";
+                } else {
+                    $guidance = self::get_column_guidance($column);
+                    $errorVerb = ($error['error_type'] === 'invalid_field_format') ? 'Invalid format' : 'Invalid value';
+                    $error['message'] = "{$errorVerb} for column '{$column}' ({$rowLabel}). {$guidance}";
+                }
 
                 // Build details array from unique values
                 if (!empty($error['_values'])) {
@@ -435,6 +445,7 @@ class SubmissionFileValidation
 
             // Clean up temporary and row-specific fields
             unset($error['_values']);
+            unset($error['_group_message']);
             unset($error['row']);
             unset($error['sgc_id']);
             unset($error['local_key']);
@@ -880,9 +891,9 @@ class SubmissionFileValidation
                 $validator_method = self::$COLUMN_MAP[$column_name]['validator_with_argument']['method'];
                 $return = call_user_func($validator_method, $value);
                 if ($return === null ) {
-                    $guidance = self::get_column_guidance($column_name);
+                    $custom_message = self::$COLUMN_MAP[$column_name]['validator_with_argument']['message'] ?? null;
                     $truncated_value = mb_strlen($value) > 80 ? mb_substr($value, 0, 80) . '...' : $value;
-                    $validation_results[] = [
+                    $error = [
                         'error_type' => 'invalid_field_value',
                         'severity' => self::SEVERITY_ERROR,
                         'validation_type' => self::DATA_VALIDATION,
@@ -891,8 +902,14 @@ class SubmissionFileValidation
                         'value' => $truncated_value,
                         'sgc_id' => $sgc_id,
                         'local_key' => $local_key,
-                        'message' => "Invalid value for column '{$column_name}': '{$truncated_value}'. {$guidance}",
+                        'message' => $custom_message
+                            ? "{$custom_message}: '{$truncated_value}'."
+                            : "Invalid value for column '{$column_name}': '{$truncated_value}'.",
                     ];
+                    if ($custom_message) {
+                        $error['group_message'] = $custom_message;
+                    }
+                    $validation_results[] = $error;
                     // No need to set flag here as this is the last check
                 }
             }

--- a/app/Services/SubmissionFileValidation.php
+++ b/app/Services/SubmissionFileValidation.php
@@ -86,7 +86,7 @@ class SubmissionFileValidation
             'desc' => 'Disease ID (MONDO)',
             'required' => true,
             # MONDO:#####, OMIM:#### or ORPHA:######/Orphanet:######
-            'regexp' => '/^(\d+|(MONDO|OMIM|ORPHA|Orphanet):\d+)$/i',
+            'regexp' => '/^(MONDO|OMIM|ORPHA|Orphanet):\d+$/i',
             'validator_with_argument' => [
                 'method' => [Disease::class, 'rosettaForSubmission'],
                 'message' => 'No MONDO associated disease value for submitted OMIM or ORPHA disease id',

--- a/deployment/ansible/inventories/group_vars/production/vars.yml
+++ b/deployment/ansible/inventories/group_vars/production/vars.yml
@@ -2,7 +2,7 @@
 # Production environment overrides.
 
 # Container images
-gencc_sub_image: ghcr.io/genecurationcoalition/gencc-sub:2.0.5
+gencc_sub_image: ghcr.io/genecurationcoalition/gencc-sub:2.0.6
 gencc_search_image: ghcr.io/genecurationcoalition/gencc-search:2.0.3
 
 # Public routing / TLS

--- a/deployment/ansible/inventories/group_vars/staging/vars.yml
+++ b/deployment/ansible/inventories/group_vars/staging/vars.yml
@@ -2,7 +2,7 @@
 # Staging environment overrides.
 
 # Container images
-gencc_sub_image: ghcr.io/genecurationcoalition/gencc-sub:2.0.5
+gencc_sub_image: ghcr.io/genecurationcoalition/gencc-sub:2.0.6
 gencc_search_image: ghcr.io/genecurationcoalition/gencc-search:2.0.3
 
 # Public routing / TLS

--- a/ecosystem.dev.config.cjs
+++ b/ecosystem.dev.config.cjs
@@ -5,6 +5,9 @@ module.exports = {
       script: 'artisan',
       interpreter: 'php',
       args: 'serve --host=0.0.0.0 --port=8001',
+      env: {
+        XDEBUG_MODE: 'off',
+      },
       instances: 1,
       autorestart: true,
       watch: false,
@@ -36,6 +39,9 @@ module.exports = {
       script: 'artisan',
       interpreter: 'php',
       args: 'queue:work --tries=3 --timeout=3600 --memory=2048 --sleep=3 --max-jobs=1000',
+      env: {
+        XDEBUG_MODE: 'off',
+      },
       instances: 1,
       autorestart: true,
       watch: false,

--- a/tests/Unit/DiseaseUpdateRefactoringTest.php
+++ b/tests/Unit/DiseaseUpdateRefactoringTest.php
@@ -203,7 +203,7 @@ class DiseaseUpdateRefactoringTest extends TestCase
     /**
      * Test rosetta with bare OMIM ID (no prefix)
      */
-    public function test_rosetta_handles_bare_omim_id()
+    public function test_rosetta_rejects_bare_omim_id()
     {
         $mondoDisease = Disease::factory()->create([
             'type' => Disease::TYPE_MONDO,
@@ -220,8 +220,12 @@ class DiseaseUpdateRefactoringTest extends TestCase
             'status' => Disease::STATUS_ACTIVE
         ]);
 
-        $result = Disease::rosetta('615438');  // No OMIM: prefix
+        // Bare numbers without CURIE prefix should be rejected
+        $result = Disease::rosetta('615438');
+        $this->assertNull($result);
 
+        // With proper CURIE prefix should resolve
+        $result = Disease::rosetta('OMIM:615438');
         $this->assertNotNull($result);
         $this->assertEquals($mondoDisease->id, $result->id);
     }


### PR DESCRIPTION
## Summary
- Fix `Job::STATUS_ERRORS` undefined constant that crashed background upload processing
- Trim all spreadsheet cell values in Phase 2 to handle whitespace contamination (leading/trailing spaces, tabs, newlines from Excel)
- Set proper draft status (`new`/`republish`) on submissions with validation errors so they are editable/deletable in the UI
- Add `Disease::rosettaForSubmission()` for stricter Phase 1 validation — rejects OMIM IDs where the MONDO record doesn't reciprocate the mapping in its xrefs, making Phase 1 consistent with Phase 2's cache-based lookup
- Custom error message for OMIM/ORPHA IDs without MONDO mapping, distinct from format validation errors
- Disable xdebug in PM2 dev config to prevent PHP 8.4 deprecation cascade crashes
- Update deploy image tags to 2.0.6
- fixes issue #84 

## Test plan
- [ ] Upload a spreadsheet with OMIM IDs that have no MONDO xref mapping (e.g., OMIM:141749, OMIM:300910) — should fail Phase 1 with "No MONDO associated disease value for submitted OMIM or ORPHA disease id"
- [ ] Upload a spreadsheet with whitespace in disease ID cells — should process correctly after trimming
- [ ] Upload a spreadsheet with some invalid fields — errored submissions should be editable and deletable in the UI
- [ ] Verify format errors (bad namespace, missing colon) still show "Invalid format for column 'disease_id'" message
- [ ] Verify valid OMIM and MONDO IDs still pass validation and process correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)