### PR TITLE
Fix submitter activation clearing form data

### DIFF
--- a/app/Http/Controllers/API/AdminController.php
+++ b/app/Http/Controllers/API/AdminController.php
@@ -305,9 +305,15 @@ class AdminController extends Controller
         ]);
 
         $submitter->name = $validated['name'];
-        $submitter->description = $validated['description'] ?? null;
-        $submitter->website = $validated['website'] ?? null;
-        $submitter->assertion = $validated['assertion'] ?? null;
+        if ($request->has('description')) {
+            $submitter->description = $validated['description'] ?? null;
+        }
+        if ($request->has('website')) {
+            $submitter->website = $validated['website'] ?? null;
+        }
+        if ($request->has('assertion')) {
+            $submitter->assertion = $validated['assertion'] ?? null;
+        }
 
         if (isset($validated['status'])) {
             $submitter->status = $validated['status'];


### PR DESCRIPTION
## Summary
- Fixes a bug where activating a newly created submitter wiped `description`, `website`, and `assertion` fields
- The `reactivateSubmitter()` frontend call only sends `name` and `status`, but the backend unconditionally overwrote the three optional fields with `null` when absent from the request
- Wraps the three assignments in `$request->has()` checks, matching the pattern already used for `allow_submissions`, `downloadable`, `contact_id`, and `logo` in the same method



## Test plan
- [ ] Create a new submitter, fill in all fields (name, description, website, assertion), save
- [ ] Click "Activate" — verify all fields are preserved
- [ ] Edit a submitter normally — verify all fields still update correctly
- [ ] Clear a field (e.g. description) via the edit dialog — verify it saves as empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)