### PR TITLE
Fix ClinGen pipeline missing gene/disease/MOI for JSON-LD references

### DIFF
--- a/scripts/clingen/sources.py
+++ b/scripts/clingen/sources.py
@@ -123,7 +123,9 @@ class GeneGraphProcessor:
             pubmed_ids = ', '.join(pmids_sorted)
 
             # Extract gene, disease, MOI from proposition
-            proposition = data.get('proposition', {})
+            # The proposition may be inline (full object) or a JSON-LD reference
+            # (dict with only an 'id' key). Resolve references before extracting.
+            proposition = self._resolve_reference(data, data.get('proposition', {}))
             gene_id = self._transform_gene(proposition.get('subjectGene', ''))
             disease_id = self._transform_disease(proposition.get('objectCondition', ''))
             mode_of_inheritance = self._transform_moi(proposition.get('qualifierModeOfInheritance', ''))
@@ -272,6 +274,43 @@ class GeneGraphProcessor:
         elif isinstance(obj, list):
             for item in obj:
                 self._extract_pmids_recursive(item, pmids)
+
+    @staticmethod
+    def _resolve_reference(document: Dict, obj: Any) -> Dict:
+        """Resolve a JSON-LD reference to its full inline object.
+
+        In the GeneGraph JSON-LD data, a nested object (e.g. ``proposition``)
+        can appear in two forms:
+
+        * **Inline** — a dict containing the full set of fields.
+        * **Reference** — a dict whose only key is ``id``, pointing to an
+          object defined elsewhere in the document.
+
+        When ``obj`` is a reference, this method searches ``dc:isVersionOf``
+        for an object whose ``id`` matches and returns it.  If no match is
+        found (or ``obj`` is already inline), the original ``obj`` is returned
+        unchanged.
+        """
+        if not isinstance(obj, dict):
+            return obj if isinstance(obj, dict) else {}
+
+        # Already inline — has more than just 'id'
+        if set(obj.keys()) != {'id'}:
+            return obj
+
+        ref_id = obj['id']
+
+        # Search dc:isVersionOf for the matching object
+        version_of = document.get('dc:isVersionOf')
+        if version_of is None:
+            return obj
+
+        candidates = version_of if isinstance(version_of, list) else [version_of]
+        for candidate in candidates:
+            if isinstance(candidate, dict) and candidate.get('id') == ref_id:
+                return candidate
+
+        return obj
 
     def _to_str(self, value: Any) -> str:
         """Coerce a value that may be a list to a semicolon-separated string."""

--- a/scripts/clingen/sources.py
+++ b/scripts/clingen/sources.py
@@ -292,7 +292,7 @@ class GeneGraphProcessor:
         unchanged.
         """
         if not isinstance(obj, dict):
-            return obj if isinstance(obj, dict) else {}
+            return {}
 
         # Already inline — has more than just 'id'
         if set(obj.keys()) != {'id'}:


### PR DESCRIPTION
## Summary
- 14 of ~3,477 GeneGraph JSON records use JSON-LD references for the `proposition` field — a dict with only `{"id": "..."}` instead of inline gene/disease/MOI data
- The actual data is present in `dc:isVersionOf` as a matching object, but the pipeline wasn't looking there
- Adds a general-purpose `_resolve_reference()` method that detects reference-only objects and resolves them via `dc:isVersionOf`, so the pipeline handles both inline and by-reference forms
- All 14 previously missing records now resolve correctly; the 3,463 inline records are unaffected

## Example
Record `1fd650d7-6a84-4b33-b86e-d34cab5b7d57` (NOD2 / Blau syndrome / Definitive):
- **Before:** gene, disease, and MOI all empty in `changed_submissions.csv`
- **After:** correctly extracted as `HGNC:5331`, `MONDO:0008523`, `HP:0000006`

## Test plan
- [ ] Run `python3 scripts/run_clingen_pipeline.py --keep-extracted`
- [ ] Verify `data/clingen/gene_validity_processed.tsv` has no empty gene/disease/MOI columns
- [ ] Spot-check record `1fd650d7` in the output

🤖 Generated with [Claude Code](https://claude.com/claude-code)