### PR TITLE
Fix ClinGen pipeline for GeneGraph IRI format change

### DIFF
--- a/scripts/clingen/config.py
+++ b/scripts/clingen/config.py
@@ -127,6 +127,7 @@ SOP_VERSION_URL_MAP: Dict[str, str] = {
     'GeneValidityCriteria9': 'https://clinicalgenome.org/docs/gene-disease-validity-standard-operating-procedure-version-9/',
     'GeneValidityCriteria10': 'https://clinicalgenome.org/docs/gene-disease-validity-standard-operating-procedures-version-10/',
     'GeneValidityCriteria11': 'https://clinicalgenome.org/docs/gene-disease-validity-standard-operating-procedures-version-11/',
+    'GeneValidityCriteria12': 'https://clinicalgenome.org/docs/gene-disease-validity-standard-operating-procedures-version-12/',
 }
 
 # Default SOP URL for unknown versions
@@ -198,8 +199,14 @@ def get_classification_id(classification: str) -> str:
 
 
 def get_assertion_criteria_url(sop_version: str) -> str:
-    """Get the assertion criteria URL based on SOP version"""
-    return SOP_VERSION_URL_MAP.get(sop_version, DEFAULT_SOP_URL)
+    """Get the assertion criteria URL based on SOP version.
+
+    GeneGraph now prefixes the version with a 'cg:' CURIE namespace
+    (e.g. 'cg:GeneValidityCriteria10'); strip any namespace prefix before lookup
+    so both the bare and prefixed forms resolve.
+    """
+    version = (sop_version or '').split(':')[-1].strip()
+    return SOP_VERSION_URL_MAP.get(version, DEFAULT_SOP_URL)
 
 
 def ensure_directories():

--- a/scripts/clingen/sources.py
+++ b/scripts/clingen/sources.py
@@ -128,7 +128,11 @@ class GeneGraphProcessor:
             proposition = self._resolve_reference(data, data.get('proposition', {}))
             gene_id = self._transform_gene(proposition.get('subjectGene', ''))
             disease_id = self._transform_disease(proposition.get('objectCondition', ''))
-            mode_of_inheritance = self._transform_moi(proposition.get('qualifierModeOfInheritance', ''))
+            # GeneGraph renamed this key from 'qualifierModeOfInheritance' to
+            # 'modeOfInheritanceQualifier'; accept both for backward compatibility.
+            moi_raw = proposition.get('modeOfInheritanceQualifier',
+                                      proposition.get('qualifierModeOfInheritance', ''))
+            mode_of_inheritance = self._transform_moi(moi_raw)
 
             # SOP version and classification
             sop_version = data.get('specifiedBy', '')
@@ -321,25 +325,46 @@ class GeneGraphProcessor:
         return str(value)
 
     def _transform_gene(self, gene: Any) -> str:
-        """Transform gene ID from hgnc:5036 to HGNC:5036."""
+        """Transform gene ID to HGNC:5036.
+
+        Handles both the CURIE form (hgnc:5036) and the full IRI GeneGraph now
+        emits (https://identifiers.org/hgnc:5036).
+        """
         gene = self._to_str(gene)
         if not gene:
             return ''
+        match = re.search(r'(?i)hgnc[:_](\d+)', gene)
+        if match:
+            return f'HGNC:{match.group(1)}'
         return gene.upper()
 
     def _transform_disease(self, disease: Any) -> str:
-        """Transform disease ID from obo:MONDO_999999 to MONDO:999999."""
+        """Transform disease ID to MONDO:999999.
+
+        Handles the CURIE form (obo:MONDO_999999) and the full OBO IRI GeneGraph
+        now emits (http://purl.obolibrary.org/obo/MONDO_0015452).
+        """
         disease = self._to_str(disease)
         if not disease:
             return ''
-        return re.sub(r'(?i)obo:MONDO_', 'MONDO:', disease).upper()
+        match = re.search(r'(?i)(MONDO|OMIM|ORPHA)[:_](\d+)', disease)
+        if match:
+            return f'{match.group(1).upper()}:{match.group(2)}'
+        return disease.upper()
 
     def _transform_moi(self, moi: Any) -> str:
-        """Transform MOI from obo:HP_999999 to HP:999999."""
+        """Transform MOI to HP:999999.
+
+        Handles the CURIE form (obo:HP_999999) and the full OBO IRI GeneGraph
+        now emits (http://purl.obolibrary.org/obo/HP_0000006).
+        """
         moi = self._to_str(moi)
         if not moi:
             return ''
-        return re.sub(r'(?i)obo:HP_', 'HP:', moi).upper()
+        match = re.search(r'(?i)HP[:_](\d+)', moi)
+        if match:
+            return f'HP:{match.group(1)}'
+        return moi.upper()
 
     def _clean_notes(self, notes: Any) -> str:
         """Clean and normalize notes field."""


### PR DESCRIPTION
## Summary

GeneGraph changed its gene-validity JSON-LD serialization (full IRIs instead of CURIEs, plus a renamed MOI key), which silently broke four fields in the GeneGraph processor of `run_clingen_pipeline.py`. **MOI was the most visible symptom** — it came out completely empty — but gene, disease, and assertion-criteria URL were also wrong.

| Field | Root cause | Result before fix |
|-------|-----------|-------------------|
| **MOI** | Key renamed `qualifierModeOfInheritance` → `modeOfInheritanceQualifier`; value now `http://purl.obolibrary.org/obo/HP_…` | 100% empty |
| **Gene** | `subjectGene` now `https://identifiers.org/hgnc:…` | uppercased URL instead of `HGNC:…` |
| **Disease** | `objectCondition` now `http://purl.obolibrary.org/obo/MONDO_…` | uppercased URL instead of `MONDO:…` |
| **Assertion Criteria URL** | `specifiedBy` now CURIE-prefixed (`cg:GeneValidityCriteria10`); map keys were bare, so every lookup hit the default fallback | wrong URL on ~3,400 records |

## Changes

- `scripts/clingen/sources.py` — read the new MOI key (with fallback to the old name); rewrote `_transform_gene` / `_transform_disease` / `_transform_moi` to extract the ID via regex that accepts **both** the old CURIE and new IRI forms.
- `scripts/clingen/config.py` — `get_assertion_criteria_url` strips the `cg:` namespace before lookup; added the **SOP version 12** URL (verified live; released Feb 2026).

## Verification

Ran the full pipeline against the current dataset:
- **0 empty** `gene_id` / `disease_id` / `mode_of_inheritance` / `assertion_criteria_url` across all 3,585 GeneGraph records.
- **0** records falling back to the default SOP URL.
- Spurious "changed" records collapsed from **3,428 → ~614**; remaining diffs are genuine upstream updates (new PMIDs, SOP re-curations incl. v12 upgrades, note/date/classification edits).

Only the **GeneGraph** source was affected; the GCI Express processor uses separate MOI extraction and was unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)