### PR TITLE
Set OMIM submitter to member

### DIFF
--- a/database/migrations/2026_07_19_120000_set_omim_to_member_on_submitters_table.php
+++ b/database/migrations/2026_07_19_120000_set_omim_to_member_on_submitters_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * Change OMIM (GENCC:000109) from a submitter to a member by turning off
+     * allow_submissions. In this schema the submitter/member distinction is
+     * captured entirely by the allow_submissions flag:
+     *   allow_submissions = true  -> submitter (may submit data)
+     *   allow_submissions = false -> member (does not submit data)
+     */
+    public function up(): void
+    {
+        DB::table('submitters')
+            ->where('curie', 'GENCC:000109')
+            ->update(['allow_submissions' => false]);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * Restore OMIM to a submitter.
+     */
+    public function down(): void
+    {
+        DB::table('submitters')
+            ->where('curie', 'GENCC:000109')
+            ->update(['allow_submissions' => true]);
+    }
+};


### PR DESCRIPTION
## Summary

Changes OMIM (`GENCC:000109`) from a **submitter** to a **member** via a data migration, so the change is applied automatically on the next release/deploy (`php artisan migrate`).

In this schema the submitter/member distinction is captured entirely by the `allow_submissions` flag (originally the column was named `member` → `member_only` → `allow_submissions`, with inverted values):
- `allow_submissions = true` → submitter (may submit data)
- `allow_submissions = false` → member (does not submit data)

## Details

- New migration `2026_07_19_120000_set_omim_to_member_on_submitters_table.php`
- `up()` sets `allow_submissions = false` for OMIM; `down()` reverses it
- Targets OMIM by `curie` (stable across environments) rather than local `id`
- Idempotent and reversible

## Testing

- Ran `php artisan migrate` locally — migration applied cleanly and OMIM's `allow_submissions` is now `0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)