### PR TITLE
Refresh release exports after deployment migrations

### DIFF
--- a/.github/workflows/deploy-via-ansible.yml
+++ b/.github/workflows/deploy-via-ansible.yml
@@ -27,6 +27,11 @@ on:
         description: "Type RESTORE to allow destructive restore mode"
         required: false
         type: string
+      force_regenerate_exports:
+        description: "Force regenerate downloadable release exports even on a no-op deploy (no migrations applied)"
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   id-token: write
@@ -188,12 +193,14 @@ jobs:
             --arg db_mode "${{ steps.validate.outputs.db_mode }}" \
             --arg db_restore_source "${{ steps.validate.outputs.db_restore_source }}" \
             --arg db_restore_force "${{ steps.validate.outputs.db_restore_force }}" \
+            --arg force_regenerate_exports "${{ github.event.inputs.force_regenerate_exports }}" \
             '{
               gencc_sub_image: $sub_image,
               gencc_search_image: $search_image,
               gencc_db_bootstrap_mode: $db_mode,
               gencc_db_restore_source: $db_restore_source,
-              gencc_db_restore_force: ($db_restore_force == "true")
+              gencc_db_restore_force: ($db_restore_force == "true"),
+              gencc_force_regenerate_exports: ($force_regenerate_exports == "true")
             }' > "${RUNNER_TEMP}/extra-vars.json"
 
       - name: Run Ansible deploy playbook

--- a/app/Console/Commands/GenccRelease.php
+++ b/app/Console/Commands/GenccRelease.php
@@ -43,7 +43,7 @@ class GenccRelease extends Command
      *
      * @var string
      */
-    protected $description = 'Release pending submissions (process|repair|bootstrap)';
+    protected $description = 'Release pending submissions (process|repair|bootstrap|regenerate-exports)';
 
     /**
      * Release statistics for tracking
@@ -74,6 +74,33 @@ class GenccRelease extends Command
     protected ?Carbon $releaseDate = null;
 
     /**
+     * Export formats that failed to generate during generateSubmissionsCsv().
+     * Each entry is ['format' => string, 'message' => string]. Populated by the
+     * per-format catch blocks; consulted by regenerateExports() to fail loudly
+     * on a partial-format failure. Secondary formats (xlsx/tsv/legacy) are
+     * tolerated by process/bootstrap/repair, but a current/csv failure -- the
+     * primary download referenced by the release record -- is always fatal
+     * (see the guard at the end of generateSubmissionsCsv()).
+     */
+    protected array $exportFailures = [];
+
+    /**
+     * Require configured GCS uploads to succeed. Local-only operation remains
+     * valid when no GCS bucket is configured.
+     */
+    protected bool $strictGcsUploads = false;
+
+    /**
+     * The most recent error encountered while initializing the GCS client.
+     */
+    protected ?string $gcsAvailabilityError = null;
+
+    /**
+     * Avoid repeating the unconfigured warning for every generated object.
+     */
+    protected bool $warnedGcsUnconfigured = false;
+
+    /**
      * GCS bucket instance (lazy-loaded).
      */
     protected $gcsBucket = null;
@@ -87,6 +114,10 @@ class GenccRelease extends Command
         if ($this->gcsBucket === null) {
             $bucketName = config('filesystems.disks.gcs.bucket');
             if (empty($bucketName)) {
+                if (!$this->warnedGcsUnconfigured) {
+                    $this->warn('GCS is not configured. Export files will be stored locally.');
+                    $this->warnedGcsUnconfigured = true;
+                }
                 return null;
             }
 
@@ -96,6 +127,7 @@ class GenccRelease extends Command
                 ]);
                 $this->gcsBucket = $storage->bucket($bucketName);
             } catch (\Exception $e) {
+                $this->gcsAvailabilityError = $e->getMessage();
                 $this->warn("GCS not available: {$e->getMessage()}. Files will be stored locally.");
                 return null;
             }
@@ -119,6 +151,7 @@ class GenccRelease extends Command
         $bucket = $this->getGcsBucket();
         $prefix = config('filesystems.disks.gcs.path_prefix', 'releases');
         $fullObjectName = $prefix ? "{$prefix}/{$objectName}" : $objectName;
+        $uploadError = $this->gcsAvailabilityError;
 
         if ($bucket) {
             try {
@@ -131,6 +164,7 @@ class GenccRelease extends Command
                 $this->info("  Uploaded to GCS: {$fullObjectName}");
                 return $objectName;
             } catch (\Exception $e) {
+                $uploadError = $e->getMessage();
                 $this->warn("  GCS upload failed: {$e->getMessage()}. Falling back to local storage.");
             }
         }
@@ -143,6 +177,12 @@ class GenccRelease extends Command
             }
             File::put($localFallbackPath, $content);
             $this->info("  Stored locally: {$localFallbackPath}");
+        }
+
+        if ($this->strictGcsUploads
+            && !empty(config('filesystems.disks.gcs.bucket'))
+            && $uploadError !== null) {
+            throw new \RuntimeException("GCS publish failed for {$fullObjectName}: {$uploadError}");
         }
 
         return $objectName;
@@ -226,10 +266,64 @@ class GenccRelease extends Command
             case 'bootstrap':
                 return $this->bootstrapRelease();
 
+            case 'regenerate-exports':
+                return $this->regenerateExports();
+
             default:
                 $this->error("Invalid argument: {$arg}");
                 return 1;
         }
+    }
+
+    /**
+     * Regenerate the downloadable release export files from the current
+     * published DB state and republish them to GCS when configured.
+     *
+     * This is a narrow, side-effect-free refresh: no release record is created,
+     * no pending jobs/actions are processed, and no submitter counts are written.
+     * The only writes are the intended export objects and local export files.
+     *
+     * Use this after a data fix (e.g. a backfill migration) corrects values that
+     * appear in the exports but no new release is being cut.
+     *
+     * @return int
+     */
+    protected function regenerateExports(): int
+    {
+        $this->releaseDate = Carbon::now();
+
+        $count = Submission::where('is_live', true)
+            ->where('status', Submission::STATUS_PUBLISHED)->count();
+
+        if ($count === 0) {
+            $this->warn('No live published submissions; writing empty export files.');
+        } else {
+            $this->info("Regenerating release export files from {$count} published submissions "
+                . "(no release record, no job processing)...");
+        }
+
+        $this->exportFailures = [];
+        $this->strictGcsUploads = true;
+
+        try {
+            $this->generateSubmissionsCsv();   // regenerates current + legacy csv/tsv/xlsx and uploads to GCS
+        } catch (\Exception $e) {
+            if (empty($this->exportFailures)) {
+                $this->exportFailures[] = ['format' => 'exports', 'message' => $e->getMessage()];
+            }
+        }
+
+        if (!empty($this->exportFailures)) {
+            $this->error('One or more export formats failed to generate; exports may be partially stale:');
+            foreach ($this->exportFailures as $failure) {
+                $this->error("  - {$failure['format']}: {$failure['message']}");
+            }
+            return 1;
+        }
+
+        $this->info('Done. Release export files refreshed.');
+
+        return 0;
     }
 
     /**
@@ -1411,17 +1505,22 @@ class GenccRelease extends Command
             ->count();
 
         // Generate CSV
-        $csvDir = $currentDir . '/csv';
-        $csvTimestamped = $csvDir . '/' . $timestampedBase . '.csv';
-        Excel::store($export, 'public/current/csv/' . $timestampedBase . '.csv', 'local', \Maatwebsite\Excel\Excel::CSV);
-        $csvContent = File::get($csvTimestamped);
-        $this->uploadToGcs($csvContent, "current/csv/{$timestampedBase}.csv", 'text/csv', $csvTimestamped);
+        try {
+            $csvDir = $currentDir . '/csv';
+            $csvTimestamped = $csvDir . '/' . $timestampedBase . '.csv';
+            Excel::store($export, 'public/current/csv/' . $timestampedBase . '.csv', 'local', \Maatwebsite\Excel\Excel::CSV);
+            $csvContent = File::get($csvTimestamped);
+            $this->uploadToGcs($csvContent, "current/csv/{$timestampedBase}.csv", 'text/csv', $csvTimestamped);
 
-        $csvLatest = $csvDir . '/' . $latestBase . '.csv';
-        File::copy($csvTimestamped, $csvLatest);
-        $this->uploadToGcs($csvContent, "current/csv/{$latestBase}.csv", 'text/csv', $csvLatest);
-        $this->info("  CSV: current/csv/{$timestampedBase}.csv");
-        $this->deleteLocalFilesAfterGcsUpload([$csvTimestamped, $csvLatest]);
+            $csvLatest = $csvDir . '/' . $latestBase . '.csv';
+            File::copy($csvTimestamped, $csvLatest);
+            $this->uploadToGcs($csvContent, "current/csv/{$latestBase}.csv", 'text/csv', $csvLatest);
+            $this->info("  CSV: current/csv/{$timestampedBase}.csv");
+            $this->deleteLocalFilesAfterGcsUpload([$csvTimestamped, $csvLatest]);
+        } catch (\Exception $e) {
+            $this->warn("  Failed to generate CSV: {$e->getMessage()}");
+            $this->exportFailures[] = ['format' => 'current/csv', 'message' => $e->getMessage()];
+        }
 
         // Generate XLSX
         try {
@@ -1440,6 +1539,7 @@ class GenccRelease extends Command
             $this->deleteLocalFilesAfterGcsUpload([$xlsxTimestamped, $xlsxLatest]);
         } catch (\Exception $e) {
             $this->warn("  Failed to generate XLSX: {$e->getMessage()}");
+            $this->exportFailures[] = ['format' => 'current/xlsx', 'message' => $e->getMessage()];
         }
 
         // Generate TSV (Excel::TSV doesn't set tab delimiter automatically, so we pass it explicitly)
@@ -1464,6 +1564,7 @@ class GenccRelease extends Command
             $this->deleteLocalFilesAfterGcsUpload([$tsvTimestamped, $tsvLatest]);
         } catch (\Exception $e) {
             $this->warn("  Failed to generate TSV: {$e->getMessage()}");
+            $this->exportFailures[] = ['format' => 'current/tsv', 'message' => $e->getMessage()];
         }
 
         $this->submissionsCsvFile = $timestampedBase . '.csv';
@@ -1477,6 +1578,19 @@ class GenccRelease extends Command
             'latest_base' => $latestBase,
             'submission_count' => $submissionCount,
         ]);
+
+        // The primary current/csv is the download the release record points at.
+        // Secondary formats are collected in $exportFailures and tolerated by the
+        // callers that ignore it, but a missing primary CSV must never be recorded
+        // as a successful release -- fail loudly so process/bootstrap/repair abort
+        // before writing a release record, and regenerateExports() exits non-zero.
+        foreach ($this->exportFailures as $failure) {
+            if ($failure['format'] === 'current/csv') {
+                throw new \RuntimeException(
+                    "Primary submissions CSV (current/csv) failed to generate: {$failure['message']}"
+                );
+            }
+        }
     }
 
     /**
@@ -1515,6 +1629,7 @@ class GenccRelease extends Command
             $this->deleteLocalFilesAfterGcsUpload([$csvTimestamped, $csvLatest]);
         } catch (\Exception $e) {
             $this->warn("    Failed to generate legacy CSV: {$e->getMessage()}");
+            $this->exportFailures[] = ['format' => 'legacy/csv', 'message' => $e->getMessage()];
         }
 
         // Generate legacy XLSX
@@ -1534,6 +1649,7 @@ class GenccRelease extends Command
             $this->deleteLocalFilesAfterGcsUpload([$xlsxTimestamped, $xlsxLatest]);
         } catch (\Exception $e) {
             $this->warn("    Failed to generate legacy XLSX: {$e->getMessage()}");
+            $this->exportFailures[] = ['format' => 'legacy/xlsx', 'message' => $e->getMessage()];
         }
 
         // Generate legacy TSV (Excel::TSV doesn't set tab delimiter automatically, so we pass it explicitly)
@@ -1558,6 +1674,7 @@ class GenccRelease extends Command
             $this->deleteLocalFilesAfterGcsUpload([$tsvTimestamped, $tsvLatest]);
         } catch (\Exception $e) {
             $this->warn("    Failed to generate legacy TSV: {$e->getMessage()}");
+            $this->exportFailures[] = ['format' => 'legacy/tsv', 'message' => $e->getMessage()];
         }
 
         $this->info("  Legacy format complete");

--- a/deployment/ansible/inventories/group_vars/all/vars.yml
+++ b/deployment/ansible/inventories/group_vars/all/vars.yml
@@ -62,3 +62,20 @@ gencc_db_bootstrap_mode: migrate_only
 # gencc_db_restore_source: "gs://gencc-dev/application-private/backups/gencc_sub_baseline_20260205.sql.gz"
 # gencc_db_bootstrap_mode: restore_and_migrate
 # gencc_db_restore_force: true
+
+# -----------------------------------------------------------------------------
+# Downloadable release-export refresh
+# -----------------------------------------------------------------------------
+# When true, regenerate the downloadable release export files (CSV/TSV/XLSX,
+# current + legacy) from the current published DB state and clear the search
+# app's local release-cache markers after migrations. This keeps the public
+# download links in sync with data fixes applied by migrations. To avoid the
+# export render cost (~35k published rows x 3 formats x 2 folders), the step
+# only runs when migrations actually applied or on a restore_and_migrate deploy.
+gencc_regenerate_exports_on_deploy: true
+#
+# Force the refresh even on a no-op deploy (no migrations applied). Use for an
+# out-of-band data fix with no migration, or to recover a stale environment on
+# the first deploy without faking a migration. Still gated by the master switch
+# above. Exposed as the force_regenerate_exports GitHub Actions workflow input.
+gencc_force_regenerate_exports: false

--- a/deployment/ansible/roles/db_bootstrap/tasks/main.yml
+++ b/deployment/ansible/roles/db_bootstrap/tasks/main.yml
@@ -116,3 +116,58 @@
   when:
     - gencc_db_bootstrap_mode == "restore_and_migrate"
     - gencc_release_bootstrap.stdout_lines is defined
+
+# ---------------------------------------------------------------------------
+# Refresh downloadable release exports after migrations.
+#
+# Run when migrations actually applied (data fixes may have changed exported
+# values) or on a restore_and_migrate deploy. Skipped on no-op deploys to avoid
+# the export render cost. If the cache-clear step is ever skipped, gencc-search's
+# 600s TTL still self-heals the website within <=10 min.
+# ---------------------------------------------------------------------------
+# Regenerate unless we can positively confirm the migrate run was a no-op.
+# Laravel prints "Nothing to migrate" only when no migrations ran; the match is
+# lowercased so formatting changes ("Nothing to migrate." vs "INFO  Nothing to
+# migrate") don't matter. Any other output -- migrations applied, an empty or
+# unrecognized string -- falls through to regenerate. That default is deliberate:
+# a wasted render is cheaper to recover from than silently serving stale exports.
+- name: Determine whether release exports should be regenerated
+  ansible.builtin.set_fact:
+    gencc_should_regenerate_exports: >-
+      {{
+        (gencc_regenerate_exports_on_deploy | default(true) | bool)
+        and (
+          (gencc_force_regenerate_exports | default(false) | bool)
+          or gencc_db_bootstrap_mode == "restore_and_migrate"
+          or ('nothing to migrate' not in (gencc_db_migrate_status.stdout | default('') | lower))
+        )
+      }}
+
+- name: Regenerate downloadable release exports from current DB state
+  ansible.builtin.shell: |
+    set -euo pipefail
+    sudo -iu {{ gencc_deploy_user }} bash -lc 'export XDG_RUNTIME_DIR="/run/user/$(id -u {{ gencc_deploy_user }})"; podman exec gencc-sub php artisan gencc:release regenerate-exports --no-interaction'
+  args:
+    executable: /bin/bash
+  register: gencc_regenerate_exports
+  when: gencc_should_regenerate_exports | bool
+
+- name: Clear gencc-search release cache markers
+  ansible.builtin.shell: |
+    set -euo pipefail
+    sudo -iu {{ gencc_deploy_user }} bash -lc 'export XDG_RUNTIME_DIR="/run/user/$(id -u {{ gencc_deploy_user }})"; podman exec gencc-search php artisan releases:clear-cache'
+  args:
+    executable: /bin/bash
+  register: gencc_clear_release_cache
+  when: gencc_should_regenerate_exports | bool
+  # Non-fatal: this only deletes cache markers, and gencc-search's 600s TTL
+  # self-heals if it's skipped. A marker cleanup must not block nginx/timers
+  # convergence in the roles that run after db_bootstrap.
+  failed_when: false
+
+- name: Show export regeneration and cache-clear output
+  ansible.builtin.debug:
+    msg: "{{ (gencc_regenerate_exports.stdout_lines | default([])) + (gencc_clear_release_cache.stdout_lines | default([])) }}"
+  when:
+    - gencc_should_regenerate_exports | bool
+    - gencc_regenerate_exports.stdout_lines is defined

--- a/tests/Feature/RegenerateExportsTest.php
+++ b/tests/Feature/RegenerateExportsTest.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Console\Commands\GenccRelease;
+use App\Models\Classification;
+use App\Models\Disease;
+use App\Models\Gene;
+use App\Models\Inheritance;
+use App\Models\Job;
+use App\Models\Release;
+use App\Models\Submission;
+use App\Models\Submitter;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\File;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Tests\TestCase;
+
+class RegenerateExportsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_regenerate_exports_writes_files_without_release_or_job_processing(): void
+    {
+        $this->makeLivePublishedSubmission();
+        $pendingJob = $this->makePendingJob();
+
+        $this->assertSame(0, Release::count());
+
+        $this->artisan('gencc:release', ['arg' => 'regenerate-exports', '--no-interaction' => true])
+            ->expectsOutputToContain('GCS is not configured. Export files will be stored locally.')
+            ->assertExitCode(0);
+
+        // All six export files exist and are non-empty.
+        foreach (['current', 'legacy'] as $folder) {
+            foreach (['csv', 'tsv', 'xlsx'] as $format) {
+                $path = storage_path("app/public/{$folder}/{$format}/gencc-submissions.{$format}");
+                $this->assertTrue(File::exists($path), "Missing export: {$folder}/{$format}");
+                $this->assertGreaterThan(0, File::size($path), "Empty export: {$folder}/{$format}");
+            }
+        }
+
+        // No release record was created.
+        $this->assertSame(0, Release::count());
+
+        // The pending job was not processed.
+        $pendingJob->refresh();
+        $this->assertSame(Job::STATUS_SUBMITTED, $pendingJob->status);
+    }
+
+    public function test_regenerate_exports_writes_empty_files_when_no_live_published_submissions(): void
+    {
+        $this->assertSame(0, Submission::where('is_live', true)
+            ->where('status', Submission::STATUS_PUBLISHED)->count());
+
+        $this->artisan('gencc:release', ['arg' => 'regenerate-exports', '--no-interaction' => true])
+            ->expectsOutputToContain('No live published submissions; writing empty export files.')
+            ->assertExitCode(0);
+
+        foreach (['current', 'legacy'] as $folder) {
+            foreach (['csv', 'tsv', 'xlsx'] as $format) {
+                $path = storage_path("app/public/{$folder}/{$format}/gencc-submissions.{$format}");
+                $this->assertTrue(File::exists($path), "Missing export: {$folder}/{$format}");
+                $this->assertGreaterThan(0, File::size($path), "Invalid export: {$folder}/{$format}");
+            }
+        }
+
+        $this->assertSame(0, Release::count());
+    }
+
+    public function test_regenerate_exports_fails_when_configured_gcs_upload_fails(): void
+    {
+        $this->makeLivePublishedSubmission();
+        config()->set('filesystems.disks.gcs.bucket', 'configured-test-bucket');
+
+        $command = new class extends GenccRelease
+        {
+            public function useFailingGcsBucket(): void
+            {
+                $this->gcsBucket = new class
+                {
+                    public function upload(): void
+                    {
+                        throw new \RuntimeException('simulated upload failure');
+                    }
+                };
+            }
+        };
+        $command->setLaravel($this->app);
+        $command->useFailingGcsBucket();
+
+        $output = new BufferedOutput();
+        $exitCode = $command->run(new ArrayInput(['arg' => 'regenerate-exports']), $output);
+
+        $this->assertSame(1, $exitCode, $output->fetch());
+    }
+
+    private function makeLivePublishedSubmission(): Submission
+    {
+        $submitter = Submitter::create([
+            'name' => 'Test Submitter',
+            'status' => Submitter::STATUS_ACTIVE,
+            'type' => Submitter::TYPE_SUBMITTER,
+        ]);
+        $user = User::factory()->create(['submitter_id' => $submitter->id]);
+        $job = Job::create([
+            'user_id' => $user->id,
+            'submitter_id' => $submitter->id,
+            'status' => Job::STATUS_RELEASED,
+            'type' => Job::TYPE_NONE,
+        ]);
+        $gene = Gene::create([
+            'hgnc_id' => 'HGNC:5',
+            'symbol' => 'A1BG',
+            'name' => 'alpha-1-B glycoprotein',
+            'locus_group' => 'protein-coding gene',
+            'locus_type' => 'gene with protein product',
+            'location' => '19q13.43',
+            'status' => Gene::STATUS_ACTIVE,
+        ]);
+        $disease = Disease::create([
+            'curie' => 'MONDO:0000001',
+            'name' => 'canonical disease label',
+            'status' => Disease::STATUS_ACTIVE,
+        ]);
+        $inheritance = Inheritance::create([
+            'curie' => 'HP:0000006',
+            'name' => 'Autosomal dominant',
+            'description' => 'Autosomal dominant inheritance',
+            'abbreviation' => 'AD',
+            'type' => Inheritance::TYPE_MOI,
+            'status' => Inheritance::STATUS_ACTIVE,
+        ]);
+        $classification = Classification::create([
+            'curie' => 'GENCC:100001',
+            'name' => 'Definitive',
+            'description' => 'Definitive classification',
+            'abbreviation' => 'DEF',
+            'type' => Classification::TYPE_CLASSIFICATION,
+            'status' => Classification::STATUS_ACTIVE,
+        ]);
+
+        $data = [
+            'submission_id' => null,
+            'local_key' => null,
+            'submission_label' => null,
+            'gene' => ['id' => 'HGNC:5', 'symbol' => 'A1BG'],
+            'disease' => ['id' => 'MONDO:0000001', 'name' => 'canonical disease label'],
+            'moi' => ['id' => 'HP:0000006', 'name' => 'Autosomal dominant'],
+            'classification' => ['id' => 'GENCC:100001', 'name' => 'Definitive'],
+            'additional_information' => [
+                'submitter_curie' => $submitter->curie,
+                'submitter_title' => 'Test Submitter',
+                'submitted_as_submission_id' => 'LOCAL-1',
+            ],
+            'notes' => ['display' => 'Public note', 'private' => 'Private note'],
+        ];
+
+        return Submission::create([
+            'job_id' => $job->id,
+            'user_id' => $user->id,
+            'submitter_id' => $submitter->id,
+            'gene_id' => $gene->id,
+            'disease_id' => $disease->id,
+            'inheritance_id' => $inheritance->id,
+            'classification_id' => $classification->id,
+            'status' => Submission::STATUS_PUBLISHED,
+            'is_live' => true,
+            'friendly' => 'Portal submission',
+            'local_key' => 'LOCAL-1',
+            'type' => Submission::TYPE_PORTAL_SUBMISSION,
+            'submission_data' => $data,
+            'original_submission_data' => $data,
+        ]);
+    }
+
+    private function makePendingJob(): Job
+    {
+        $submitter = Submitter::create([
+            'name' => 'Pending Submitter',
+            'status' => Submitter::STATUS_ACTIVE,
+            'type' => Submitter::TYPE_SUBMITTER,
+        ]);
+        $user = User::factory()->create(['submitter_id' => $submitter->id]);
+
+        return Job::create([
+            'user_id' => $user->id,
+            'submitter_id' => $submitter->id,
+            'status' => Job::STATUS_SUBMITTED,
+            'type' => Job::TYPE_NONE,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary

- add `gencc:release regenerate-exports` to rebuild current and legacy CSV, TSV, and XLSX files from published database state
- make configured GCS upload failures fatal for explicit regeneration
- regenerate exports after deployment migrations, with a force option for no-op migrations
- clear the search release-cache markers only after export regeneration succeeds
- expose the force option in the Ansible deployment workflow

## Verification

- `php artisan test tests/Feature/RegenerateExportsTest.php`
- built and pushed `ghcr.io/genecurationcoalition/gencc-sub:2.1.6-rc1` as `linux/amd64`
- deployed to staging with `migrate_only` and forced regeneration
- regenerated exports from 30,067 published submissions
- verified 12 successful GCS uploads: current and legacy latest/timestamped CSV, TSV, and XLSX
- verified staging play recap: `unreachable=0`, `failed=0`
- verified portal health endpoint returns HTTP 200
- verified all six release variants end to end through VM-local search and public staging

