### PR TITLE
test(deploy): add safe SSH diagnostic mode

### DIFF
--- a/.github/workflows/deploy-via-ansible.yml
+++ b/.github/workflows/deploy-via-ansible.yml
@@ -3,13 +3,21 @@ name: Deploy v2 to Staging
 on:
   workflow_dispatch:
     inputs:
+      operation:
+        description: "Operation to run"
+        required: true
+        default: "deploy"
+        type: choice
+        options:
+          - deploy
+          - ssh_diagnostic
       sub_image_tag:
         description: "gencc-sub image tag (e.g. 2.0-beta5)"
-        required: true
+        required: false
         type: string
       search_image_tag:
         description: "gencc-search image tag (e.g. 2.0-beta4a)"
-        required: true
+        required: false
         type: string
       db_bootstrap_mode:
         description: "Database bootstrap strategy"
@@ -40,6 +48,7 @@ permissions:
 
 jobs:
   deploy:
+    if: ${{ inputs.operation == 'deploy' }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
     environment: staging
@@ -68,14 +77,32 @@ jobs:
       - name: Validate inputs and derive deploy values
         id: validate
         shell: bash
+        env:
+          SUB_IMAGE_TAG: ${{ inputs.sub_image_tag }}
+          SEARCH_IMAGE_TAG: ${{ inputs.search_image_tag }}
+          DB_MODE: ${{ inputs.db_bootstrap_mode }}
+          RESTORE_SOURCE: ${{ inputs.db_restore_source }}
+          RESTORE_CONFIRM: ${{ inputs.confirm_restore }}
         run: |
           set -euo pipefail
 
-          SUB_IMAGE="${GENCC_SUB_IMAGE_REPO}:${{ inputs.sub_image_tag }}"
-          SEARCH_IMAGE="${GENCC_SEARCH_IMAGE_REPO}:${{ inputs.search_image_tag }}"
-          DB_MODE="${{ inputs.db_bootstrap_mode }}"
-          RESTORE_SOURCE="${{ inputs.db_restore_source }}"
-          RESTORE_CONFIRM="${{ inputs.confirm_restore }}"
+          if [[ -z "${SUB_IMAGE_TAG}" || -z "${SEARCH_IMAGE_TAG}" ]]; then
+            echo "sub_image_tag and search_image_tag are required for operation=deploy."
+            exit 1
+          fi
+
+          IMAGE_TAG_PATTERN='^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$'
+          if [[ ! "${SUB_IMAGE_TAG}" =~ ${IMAGE_TAG_PATTERN} ]]; then
+            echo "sub_image_tag is not a valid container image tag."
+            exit 1
+          fi
+          if [[ ! "${SEARCH_IMAGE_TAG}" =~ ${IMAGE_TAG_PATTERN} ]]; then
+            echo "search_image_tag is not a valid container image tag."
+            exit 1
+          fi
+
+          SUB_IMAGE="${GENCC_SUB_IMAGE_REPO}:${SUB_IMAGE_TAG}"
+          SEARCH_IMAGE="${GENCC_SEARCH_IMAGE_REPO}:${SEARCH_IMAGE_TAG}"
 
           RESTORE_FORCE="false"
           if [[ "${DB_MODE}" == "restore_and_migrate" ]]; then
@@ -239,3 +266,451 @@ jobs:
           delete-branch: true
           add-paths: |
             deployment/ansible/inventories/group_vars/staging/vars.yml
+
+  # This read-only mode isolates intermittent Ansible module stalls seen over
+  # SSH through IAP by comparing multiplexing, pipelining, and tunnel variants
+  # without running deployment roles. It lives in this trusted main-branch
+  # workflow so the existing GCP OIDC workflow_ref restriction accepts it.
+  ssh-diagnostic:
+    if: ${{ inputs.operation == 'ssh_diagnostic' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 50
+    environment: staging
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      GCP_PROJECT_ID: clingen-dev
+      GCP_ZONE: us-east1-b
+      GCP_INSTANCE_NAME: gencc-vm
+      GCP_WORKLOAD_IDENTITY_PROVIDER: projects/522856288592/locations/global/workloadIdentityPools/gencc-sub-gha/providers/gencc-sub-oidc
+      GCP_DEPLOY_SERVICE_ACCOUNT: gencc-deploy@clingen-dev.iam.gserviceaccount.com
+      ANSIBLE_CALLBACKS_ENABLED: ansible.posix.profile_tasks
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Guard trusted branch
+        if: ${{ github.ref != 'refs/heads/main' }}
+        shell: bash
+        run: |
+          echo "This workflow is trusted only on refs/heads/main."
+          echo "Current ref: ${GITHUB_REF}"
+          exit 1
+
+      - name: Authenticate to Google Cloud (OIDC)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.GCP_DEPLOY_SERVICE_ACCOUNT }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Install Ansible
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y ansible
+
+      - name: Create ephemeral OS Login SSH key
+        id: diagnostic_oslogin
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          ssh-keygen -t ed25519 -f "${RUNNER_TEMP}/oslogin_key" -N '' -C "gha-diagnostic-${GITHUB_RUN_ID}"
+
+          gcloud compute os-login ssh-keys add \
+            --key-file="${RUNNER_TEMP}/oslogin_key.pub" \
+            --ttl=60m \
+            --project="${GCP_PROJECT_ID}"
+
+          OSLOGIN_USERNAME="$(gcloud compute os-login describe-profile \
+            --project="${GCP_PROJECT_ID}" \
+            --format='value(posixAccounts[0].username)')"
+
+          if [[ -z "${OSLOGIN_USERNAME}" ]]; then
+            echo "Failed to resolve OS Login username."
+            exit 1
+          fi
+
+          echo "oslogin_username=${OSLOGIN_USERNAME}" >> "${GITHUB_OUTPUT}"
+
+      - name: Prepare read-only diagnostic
+        id: prepare_diagnostic
+        shell: bash
+        env:
+          OSLOGIN_USERNAME: ${{ steps.diagnostic_oslogin.outputs.oslogin_username }}
+        run: |
+          set -euo pipefail
+
+          mkdir -p "${RUNNER_TEMP}/ssh-diagnostic"
+          chmod 700 "${RUNNER_TEMP}/ssh-diagnostic"
+
+          cat > "${RUNNER_TEMP}/ssh-diagnostic/playbook.yml" <<'EOF'
+          ---
+          - name: Exercise the Ansible SSH transport
+            hosts: all
+            gather_facts: false
+            become: true
+            tasks:
+              - name: Echo 01
+                ansible.builtin.command: /usr/bin/echo Hello
+                changed_when: false
+              - name: Echo 02
+                ansible.builtin.command: /usr/bin/echo Hello
+                changed_when: false
+              - name: Echo 03
+                ansible.builtin.command: /usr/bin/echo Hello
+                changed_when: false
+              - name: Echo 04
+                ansible.builtin.command: /usr/bin/echo Hello
+                changed_when: false
+              - name: Echo 05
+                ansible.builtin.command: /usr/bin/echo Hello
+                changed_when: false
+              - name: Echo 06
+                ansible.builtin.command: /usr/bin/echo Hello
+                changed_when: false
+              - name: Echo 07
+                ansible.builtin.command: /usr/bin/echo Hello
+                changed_when: false
+              - name: Echo 08
+                ansible.builtin.command: /usr/bin/echo Hello
+                changed_when: false
+              - name: Echo 09
+                ansible.builtin.command: /usr/bin/echo Hello
+                changed_when: false
+              - name: Echo 10
+                ansible.builtin.command: /usr/bin/echo Hello
+                changed_when: false
+          EOF
+
+          for CASE in case1 case2 case3; do
+            CONTROL_PATH="${RUNNER_TEMP}/ssh-diagnostic/${CASE}-%C"
+            CONTROL_MASTER="auto"
+            CONTROL_PERSIST="20m"
+            if [[ "${CASE}" == "case2" ]]; then
+              CONTROL_MASTER="no"
+              CONTROL_PERSIST="no"
+            fi
+
+            cat > "${RUNNER_TEMP}/ssh-diagnostic/${CASE}.ssh_config" <<EOF
+          Host ${GCP_INSTANCE_NAME}
+            HostName ${GCP_INSTANCE_NAME}
+            User ${OSLOGIN_USERNAME}
+            IdentityFile ${RUNNER_TEMP}/oslogin_key
+            IdentitiesOnly yes
+            ControlMaster ${CONTROL_MASTER}
+            ControlPersist ${CONTROL_PERSIST}
+            ControlPath ${CONTROL_PATH}
+            ServerAliveInterval 30
+            ServerAliveCountMax 4
+            TCPKeepAlive yes
+            ConnectTimeout 20
+            StrictHostKeyChecking no
+            UserKnownHostsFile /dev/null
+            ProxyCommand gcloud compute start-iap-tunnel %h %p --listen-on-stdin --project ${GCP_PROJECT_ID} --zone ${GCP_ZONE}
+          EOF
+          done
+
+          chmod 600 "${RUNNER_TEMP}/ssh-diagnostic/"*.ssh_config
+
+      - name: Case 1 - current multiplexing and pipelining
+        id: case1
+        if: ${{ always() && steps.diagnostic_oslogin.outcome == 'success' && steps.prepare_diagnostic.outcome == 'success' }}
+        continue-on-error: true
+        timeout-minutes: 8
+        shell: bash
+        env:
+          ANSIBLE_PIPELINING: "true"
+          ANSIBLE_SSH_ARGS: -F ${{ runner.temp }}/ssh-diagnostic/case1.ssh_config
+        run: |
+          set -uo pipefail
+          RESULT_FILE="${RUNNER_TEMP}/ssh-diagnostic/case1.result"
+          LOG_FILE="${RUNNER_TEMP}/ssh-diagnostic/case1.log"
+          STARTED_AT="$(date +%s)"
+          printf 'started_at=%s\n' "${STARTED_AT}" > "${RESULT_FILE}"
+
+          timeout --signal=TERM --kill-after=10s 470s \
+            ansible-playbook \
+              -i "${GCP_INSTANCE_NAME}," \
+              "${RUNNER_TEMP}/ssh-diagnostic/playbook.yml" \
+              -vvv 2>&1 | tee "${LOG_FILE}"
+          STATUS=${PIPESTATUS[0]}
+
+          FINISHED_AT="$(date +%s)"
+          {
+            printf 'finished_at=%s\n' "${FINISHED_AT}"
+            printf 'duration_seconds=%s\n' "$((FINISHED_AT - STARTED_AT))"
+            printf 'exit_code=%s\n' "${STATUS}"
+          } >> "${RESULT_FILE}"
+
+          ssh -F "${RUNNER_TEMP}/ssh-diagnostic/case1.ssh_config" \
+            -O exit "${GCP_INSTANCE_NAME}" >/dev/null 2>&1 || true
+          exit "${STATUS}"
+
+      - name: Upload case 1 log
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ssh-diagnostic-case1-${{ github.run_id }}
+          path: ${{ runner.temp }}/ssh-diagnostic/case1.log
+          if-no-files-found: warn
+
+      - name: Case 2 - no multiplexing, pipelining retained
+        id: case2
+        if: ${{ always() && steps.diagnostic_oslogin.outcome == 'success' && steps.prepare_diagnostic.outcome == 'success' }}
+        continue-on-error: true
+        timeout-minutes: 8
+        shell: bash
+        env:
+          ANSIBLE_PIPELINING: "true"
+          ANSIBLE_SSH_ARGS: -F ${{ runner.temp }}/ssh-diagnostic/case2.ssh_config
+        run: |
+          set -uo pipefail
+          RESULT_FILE="${RUNNER_TEMP}/ssh-diagnostic/case2.result"
+          LOG_FILE="${RUNNER_TEMP}/ssh-diagnostic/case2.log"
+          STARTED_AT="$(date +%s)"
+          printf 'started_at=%s\n' "${STARTED_AT}" > "${RESULT_FILE}"
+
+          timeout --signal=TERM --kill-after=10s 470s \
+            ansible-playbook \
+              -i "${GCP_INSTANCE_NAME}," \
+              "${RUNNER_TEMP}/ssh-diagnostic/playbook.yml" \
+              -vvv 2>&1 | tee "${LOG_FILE}"
+          STATUS=${PIPESTATUS[0]}
+
+          FINISHED_AT="$(date +%s)"
+          {
+            printf 'finished_at=%s\n' "${FINISHED_AT}"
+            printf 'duration_seconds=%s\n' "$((FINISHED_AT - STARTED_AT))"
+            printf 'exit_code=%s\n' "${STATUS}"
+          } >> "${RESULT_FILE}"
+          exit "${STATUS}"
+
+      - name: Upload case 2 log
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ssh-diagnostic-case2-${{ github.run_id }}
+          path: ${{ runner.temp }}/ssh-diagnostic/case2.log
+          if-no-files-found: warn
+
+      - name: Case 3 - multiplexing retained, no pipelining
+        id: case3
+        if: ${{ always() && steps.diagnostic_oslogin.outcome == 'success' && steps.prepare_diagnostic.outcome == 'success' }}
+        continue-on-error: true
+        timeout-minutes: 8
+        shell: bash
+        env:
+          ANSIBLE_PIPELINING: "false"
+          ANSIBLE_SSH_ARGS: -F ${{ runner.temp }}/ssh-diagnostic/case3.ssh_config
+        run: |
+          set -uo pipefail
+          RESULT_FILE="${RUNNER_TEMP}/ssh-diagnostic/case3.result"
+          LOG_FILE="${RUNNER_TEMP}/ssh-diagnostic/case3.log"
+          STARTED_AT="$(date +%s)"
+          printf 'started_at=%s\n' "${STARTED_AT}" > "${RESULT_FILE}"
+
+          timeout --signal=TERM --kill-after=10s 470s \
+            ansible-playbook \
+              -i "${GCP_INSTANCE_NAME}," \
+              "${RUNNER_TEMP}/ssh-diagnostic/playbook.yml" \
+              -vvv 2>&1 | tee "${LOG_FILE}"
+          STATUS=${PIPESTATUS[0]}
+
+          FINISHED_AT="$(date +%s)"
+          {
+            printf 'finished_at=%s\n' "${FINISHED_AT}"
+            printf 'duration_seconds=%s\n' "$((FINISHED_AT - STARTED_AT))"
+            printf 'exit_code=%s\n' "${STATUS}"
+          } >> "${RESULT_FILE}"
+
+          ssh -F "${RUNNER_TEMP}/ssh-diagnostic/case3.ssh_config" \
+            -O exit "${GCP_INSTANCE_NAME}" >/dev/null 2>&1 || true
+          exit "${STATUS}"
+
+      - name: Upload case 3 log
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ssh-diagnostic-case3-${{ github.run_id }}
+          path: ${{ runner.temp }}/ssh-diagnostic/case3.log
+          if-no-files-found: warn
+
+      - name: Case 4 - standalone IAP listener with multiplexing and pipelining
+        id: case4
+        if: ${{ always() && steps.diagnostic_oslogin.outcome == 'success' && steps.prepare_diagnostic.outcome == 'success' }}
+        continue-on-error: true
+        timeout-minutes: 8
+        shell: bash
+        env:
+          ANSIBLE_PIPELINING: "true"
+          OSLOGIN_USERNAME: ${{ steps.diagnostic_oslogin.outputs.oslogin_username }}
+        run: |
+          set -uo pipefail
+          RESULT_FILE="${RUNNER_TEMP}/ssh-diagnostic/case4.result"
+          LOG_FILE="${RUNNER_TEMP}/ssh-diagnostic/case4.log"
+          IAP_LOG_FILE="${RUNNER_TEMP}/ssh-diagnostic/case4-iap.log"
+          PID_FILE="${RUNNER_TEMP}/ssh-diagnostic/case4-iap.pid"
+          STARTED_AT="$(date +%s)"
+          printf 'started_at=%s\n' "${STARTED_AT}" > "${RESULT_FILE}"
+
+          IAP_PORT="$(python3 -c 'import socket; s = socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')"
+          gcloud compute start-iap-tunnel "${GCP_INSTANCE_NAME}" 22 \
+            --local-host-port="127.0.0.1:${IAP_PORT}" \
+            --project="${GCP_PROJECT_ID}" \
+            --zone="${GCP_ZONE}" > "${IAP_LOG_FILE}" 2>&1 &
+          IAP_PID=$!
+          printf '%s\n' "${IAP_PID}" > "${PID_FILE}"
+
+          cleanup_case4() {
+            ssh -F "${RUNNER_TEMP}/ssh-diagnostic/case4.ssh_config" \
+              -O exit "${GCP_INSTANCE_NAME}" >/dev/null 2>&1 || true
+            kill "${IAP_PID}" >/dev/null 2>&1 || true
+            wait "${IAP_PID}" >/dev/null 2>&1 || true
+            rm -f "${PID_FILE}"
+          }
+          trap cleanup_case4 EXIT
+
+          for _ in {1..20}; do
+            if bash -c "exec 3<>/dev/tcp/127.0.0.1/${IAP_PORT}" 2>/dev/null; then
+              IAP_READY="true"
+              break
+            fi
+            if ! kill -0 "${IAP_PID}" 2>/dev/null; then
+              echo "Standalone IAP listener exited before accepting connections." | tee "${LOG_FILE}"
+              cat "${IAP_LOG_FILE}" | tee -a "${LOG_FILE}"
+              exit 1
+            fi
+            sleep 1
+          done
+          if [[ "${IAP_READY:-false}" != "true" ]]; then
+            echo "Standalone IAP listener did not become ready." | tee "${LOG_FILE}"
+            cat "${IAP_LOG_FILE}" | tee -a "${LOG_FILE}"
+            exit 1
+          fi
+
+          cat > "${RUNNER_TEMP}/ssh-diagnostic/case4.ssh_config" <<EOF
+          Host ${GCP_INSTANCE_NAME}
+            HostName 127.0.0.1
+            Port ${IAP_PORT}
+            User ${OSLOGIN_USERNAME}
+            IdentityFile ${RUNNER_TEMP}/oslogin_key
+            IdentitiesOnly yes
+            ControlMaster auto
+            ControlPersist 20m
+            ControlPath ${RUNNER_TEMP}/ssh-diagnostic/case4-%C
+            ServerAliveInterval 30
+            ServerAliveCountMax 4
+            TCPKeepAlive yes
+            ConnectTimeout 20
+            StrictHostKeyChecking no
+            UserKnownHostsFile /dev/null
+          EOF
+          chmod 600 "${RUNNER_TEMP}/ssh-diagnostic/case4.ssh_config"
+          export ANSIBLE_SSH_ARGS="-F ${RUNNER_TEMP}/ssh-diagnostic/case4.ssh_config"
+
+          timeout --signal=TERM --kill-after=10s 470s \
+            ansible-playbook \
+              -i "${GCP_INSTANCE_NAME}," \
+              "${RUNNER_TEMP}/ssh-diagnostic/playbook.yml" \
+              -vvv 2>&1 | tee "${LOG_FILE}"
+          STATUS=${PIPESTATUS[0]}
+
+          FINISHED_AT="$(date +%s)"
+          {
+            printf 'finished_at=%s\n' "${FINISHED_AT}"
+            printf 'duration_seconds=%s\n' "$((FINISHED_AT - STARTED_AT))"
+            printf 'exit_code=%s\n' "${STATUS}"
+          } >> "${RESULT_FILE}"
+          exit "${STATUS}"
+
+      - name: Upload case 4 logs
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ssh-diagnostic-case4-${{ github.run_id }}
+          path: |
+            ${{ runner.temp }}/ssh-diagnostic/case4.log
+            ${{ runner.temp }}/ssh-diagnostic/case4-iap.log
+          if-no-files-found: warn
+
+      - name: Summarize diagnostic results
+        if: ${{ always() }}
+        shell: bash
+        env:
+          CASE1_OUTCOME: ${{ steps.case1.outcome }}
+          CASE2_OUTCOME: ${{ steps.case2.outcome }}
+          CASE3_OUTCOME: ${{ steps.case3.outcome }}
+          CASE4_OUTCOME: ${{ steps.case4.outcome }}
+        run: |
+          set -u
+          {
+            echo "## Ansible SSH diagnostic"
+            echo
+            echo "| Case | Configuration | Outcome | Wall clock | Exit code |"
+            echo "| --- | --- | --- | ---: | ---: |"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+          for CASE_NUMBER in 1 2 3 4; do
+            case "${CASE_NUMBER}" in
+              1)
+                DESCRIPTION="ProxyCommand; ControlMaster on; pipelining on"
+                OUTCOME="${CASE1_OUTCOME}"
+                ;;
+              2)
+                DESCRIPTION="ProxyCommand; ControlMaster off; pipelining on"
+                OUTCOME="${CASE2_OUTCOME}"
+                ;;
+              3)
+                DESCRIPTION="ProxyCommand; ControlMaster on; pipelining off"
+                OUTCOME="${CASE3_OUTCOME}"
+                ;;
+              4)
+                DESCRIPTION="Standalone IAP listener; ControlMaster on; pipelining on"
+                OUTCOME="${CASE4_OUTCOME}"
+                ;;
+            esac
+
+            RESULT_FILE="${RUNNER_TEMP}/ssh-diagnostic/case${CASE_NUMBER}.result"
+            started_at=""
+            duration_seconds=""
+            exit_code=""
+            if [[ -f "${RESULT_FILE}" ]]; then
+              source "${RESULT_FILE}"
+              if [[ -z "${duration_seconds}" && -n "${started_at}" ]]; then
+                duration_seconds="$(( $(date +%s) - started_at ))"
+              fi
+            fi
+
+            printf '| %s | %s | %s | %s s | %s |\n' \
+              "${CASE_NUMBER}" "${DESCRIPTION}" "${OUTCOME}" \
+              "${duration_seconds:-unknown}" "${exit_code:-unknown}" >> "${GITHUB_STEP_SUMMARY}"
+          done
+
+      - name: Clean up diagnostic resources
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set +e
+
+          if [[ -f "${RUNNER_TEMP}/ssh-diagnostic/case4-iap.pid" ]]; then
+            IAP_PID="$(cat "${RUNNER_TEMP}/ssh-diagnostic/case4-iap.pid")"
+            kill "${IAP_PID}" >/dev/null 2>&1 || true
+            wait "${IAP_PID}" >/dev/null 2>&1 || true
+          fi
+
+          for CASE in case1 case3 case4; do
+            CONFIG="${RUNNER_TEMP}/ssh-diagnostic/${CASE}.ssh_config"
+            if [[ -f "${CONFIG}" ]]; then
+              ssh -F "${CONFIG}" -O exit "${GCP_INSTANCE_NAME}" >/dev/null 2>&1 || true
+            fi
+          done
+
+          rm -f "${RUNNER_TEMP}/oslogin_key" "${RUNNER_TEMP}/oslogin_key.pub"
+          rm -rf "${RUNNER_TEMP}/ssh-diagnostic"


### PR DESCRIPTION
## Summary

- add a read-only SSH diagnostic operation to the trusted staging deployment workflow
- compare ProxyCommand, SSH multiplexing, Ansible pipelining, and a standalone IAP listener
- preserve the existing deploy path as the default and validate deploy-only image inputs there
- upload per-case verbose logs and wall-clock results without running deployment roles

## Verification

- workflow YAML parsed locally
- embedded diagnostic playbook passed `ansible-playbook --syntax-check`
- workflow Bash blocks passed `bash -n`
- `git diff --check` passed

This must be merged to `main` before dispatch because the staging GCP WIF condition requires this workflow file at `refs/heads/main`.