### PR TITLE
chore(deploy): pin production images to 2.1.6

### DIFF
--- a/deployment/ansible/inventories/group_vars/production/vars.yml
+++ b/deployment/ansible/inventories/group_vars/production/vars.yml
@@ -2,8 +2,8 @@
 # Production environment overrides.
 
 # Container images
-gencc_sub_image: ghcr.io/genecurationcoalition/gencc-sub:2.1.4
-gencc_search_image: ghcr.io/genecurationcoalition/gencc-search:2.1.5
+gencc_sub_image: ghcr.io/genecurationcoalition/gencc-sub:2.1.6
+gencc_search_image: ghcr.io/genecurationcoalition/gencc-search:2.1.6
 
 # Public routing / TLS
 gencc_submit_hostname: portal.thegencc.org


### PR DESCRIPTION
Bumps the production image pins:

| Component | Before | After |
|---|---|---|
| gencc-sub | `2.1.4` | `2.1.6` |
| gencc-search | `2.1.5` | `2.1.6` |

Prod has no deploy workflow, so the deploy was run manually from a workstation and this commit records
the pins after verifying it. `PLAY RECAP: failed=0`; both containers report `2.1.6` and all endpoints
(`portal.thegencc.org`, `thegencc.org`, `search.thegencc.org` redirect) are healthy.

Migrate-only — no DB restore. The two migrations in this range are additive data backfills and applied
as batch 14.